### PR TITLE
Fix TypeScript definition approach

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -144,7 +144,7 @@ declare namespace ReactPIXIFiber {
    * Container properties.
    * @see http://pixijs.download/dev/docs/PIXI.Container.html
    */
-  interface ContainerProperties extends DisplayObjectProperties<Container> {}
+  interface ContainerProperties extends DisplayObjectContainerProperties<Container> {}
   /**
    * Graphics properties.
    * @see http://pixijs.download/dev/docs/PIXI.Graphics.html
@@ -154,7 +154,7 @@ declare namespace ReactPIXIFiber {
    * ParticleContainer properties.
    * @see http://pixijs.download/dev/docs/PIXI.particles.ParticleContainer.html
    */
-  interface ParticleContainerProperties extends DisplayObjectProperties<ParticleContainer> {}
+  interface ParticleContainerProperties extends DisplayObjectContainerProperties<ParticleContainer> {}
   /**
    * Sprite properties.
    * @see http://pixijs.download/dev/docs/PIXI.Sprite.html
@@ -239,12 +239,12 @@ declare namespace ReactPIXIFiber {
  * our custom components.
  */
 declare module 'react' {
-  function createElement<T extends keyof ReactPIXIFiber.PropertiesMap, P extends ReactPIXIFiber.ClassAttributes<T>>(
+  function createElement<T extends keyof ReactPIXIFiber.PropertiesMap, P extends ReactPIXIFiber.ClassAttributes<T> = {}>(
       type: T,
       props?: P | null,
       ...children: React.ReactNode[]): ReactPIXIFiber.Element<T, P>;
 
-  function cloneElement<T extends keyof ReactPIXIFiber.PropertiesMap, P extends ReactPIXIFiber.ClassAttributes<T>>(
+  function cloneElement<T extends keyof ReactPIXIFiber.PropertiesMap, P extends ReactPIXIFiber.ClassAttributes<T> = {}>(
     element: ReactPIXIFiber.Element<T, P>,
     props?: P,
     ...children: PIXI.DisplayObject[]): ReactPIXIFiber.Element<T, P>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,103 +34,90 @@ declare namespace ReactPIXIFiber {
   type DisplayObjectContainerProperties<K extends keyof ClassMap> = DisplayObjectProperties<K> & ChildrenProperties;
 
   //
-  // Component identifier types.
-  //
-
-  /** BitmapText component identifier type */
-  type BitmapText = 'BitmapText';
-  /** Container component identifier type */
-  type Container = 'Container';
-  /** Graphics component identifier type */
-  type Graphics = 'Graphics';
-  /** ParticleContainer component identifier type */
-  type ParticleContainer = 'ParticleContainer';
-  /** Sprite component identifier type */
-  type Sprite = 'Sprite';
-  /** Stage component identifier type */
-  type Stage = 'Stage';
-  /** Text component identifier type */
-  type Text = 'Text';
-  /** TilingSprite component identifier type */
-  type TilingSprite = 'TilingSprite';
-
-  //
   //  Publically exported React element types that the reconciler can identifiy. You can
   //  use these as you would other components.  This works iefei simlarly to how intrinsic elements
   //  such as HTML and SVG elements work.
   //
 
   /**
-   * BitmapText React element type.
-   * @example const text = '';
+   * BitmapText element type.
+   * @example
+   * const text = '';
    * <BitmapText text={text} />
-   * @example React.createElement(BitmapText, { text })
-   * @example // equivalent to:
-   * React.createElement('BitmapText', { text })
+   * React.createElement(BitmapText, { text });
+   * React.createElement('BitmapText', { text });
    */
+  type BitmapText = 'BitmapText'; // type identifier
   const BitmapText: BitmapText;
   /**
-   * Container React element type.
-   * @example <Container />
-   * @example React.createElement(Container)
-   * @example // equivalent to:
-   * React.createElement('Container')
+   * Container element type.
+   * @example
+   * <Container />
+   * React.createElement(Container);
+   * React.createElement('Container');
    */
+  type Container = 'Container'; // type identifier
   const Container: Container;
   /**
-   * Graphics React element type.
-   * @example <Graphics />
-   * @example React.createElement(Graphics)
-   * @example // equivalent to:
-   * React.createElement('Graphics')
+   * Graphics element type.
+   * <Graphics />
+   * React.createElement(Graphics);
+   * React.createElement('Graphics');
    */
+  type Graphics = 'Graphics'; // type identifier
   const Graphics: Graphics;
   /**
-   * ParticleContainer React element type.
-   * @example <ParticleContainer />
-   * @example React.createElement(ParticleContainer)
-   * @example // equivalent to:
-   * React.createElement('ParticleContainer')
+   * ParticleContainer element type.
+   * @example
+   * <ParticleContainer />
+   * React.createElement(ParticleContainer);
+   * React.createElement('ParticleContainer');
    */
+  type ParticleContainer = 'ParticleContainer'; // type identifier
   const ParticleContainer: ParticleContainer;
   /**
-   * Sprite React element type.
-   * @example <Sprite />
-   * @example React.createElement(Sprite)
-   * @example // equivalent to:
-   * React.createElement('Sprite')
+   * Sprite element type.
+   * @example
+   * <Sprite />
+   * React.createElement(Sprite);
+   * React.createElement('Sprite');
    */
+  type Sprite = 'Sprite'; // type identifier
   const Sprite: Sprite;
   /**
-   * Stage React element type.
-   * @example <Stage width={100} height={100} />
-   * @example React.createElement(Stage)
-   * @example // equivalent to:
-   * React.createElement('Stage')
+   * Stage element type.
+   * @example
+   * const width = 100, height = 100;
+   * <Stage width={width} height={height} />
+   * React.createElement(Stage, { width, height });
+   * React.createElement('Stage', { width, height });
    */
+  type Stage = 'Stage'; // type identifier
   const Stage: Stage;
   /**
-   * Text React element type.
-   * @example <Text />
-   * @example React.createElement(Text)
-   * @example // equivalent to:
-   * React.createElement('Text')
+   * Text element type.
+   * @example
+   * <Text />
+   * React.createElement(Text);
+   * React.createElement('Text');
   */
+  type Text = 'Text'; // Text type identifier
   const Text: Text;
   /**
-   * TilingSprite React element type.
-   * @example const texture = PIXI.Texture.fromImage(...);
+   * TilingSprite element type.
+   * @example
+   * const texture = PIXI.Texture.fromImage(...);
    * <TilingSprite texture={texture} />
-   * @example React.createElement(TilingSprite, { texture })
-   * @example // equivalent to:
-   * React.createElement('TilingSprite', { texture })
+   * React.createElement(TilingSprite, { texture });
+   * React.createElement('TilingSprite', { texture });
    */
+  type TilingSprite = 'TilingSprite'; // type identifier
   const TilingSprite: TilingSprite;
 
   //
   //  Component properties.
-  //  - `DisplayObjectProperties` do not have children.
-  //  - `DisplayObjectContainerProperties` can have children.
+  //  - `DisplayObjectProperties` _can not_ have children.
+  //  - `DisplayObjectContainerProperties` _can_ have children.
   //
 
   /**
@@ -191,7 +178,7 @@ declare namespace ReactPIXIFiber {
   /** Common class attributes. */
   interface ClassAttributes<T extends keyof InstanceMap> extends React.ClassAttributes<InstanceMap[T]> {}
 
-  /** Map React element types to the PIXI object it's properties decorate. */
+  /** Map custom element types to the PIXI object its properties decorate. */
   interface ClassMap {
     [BitmapText]: PIXI.extras.BitmapText;
     [Container]: PIXI.Container;
@@ -203,7 +190,7 @@ declare namespace ReactPIXIFiber {
     [TilingSprite]: PIXI.extras.TilingSprite;
   }
 
-  /** Map React element types to the properties the component supports. */
+  /** Map custom element types to the properties the component requires and supports. */
   interface PropertiesMap {
     [BitmapText]: BitmapTextProperties;
     [Container]: ContainerProperties;
@@ -215,7 +202,7 @@ declare namespace ReactPIXIFiber {
     [TilingSprite]: TilingSpriteProperties;
   }
 
-  /** Map React element types reference type it emits. */
+  /** Map custom element types to its `ref` type. */
   interface InstanceMap {
     [BitmapText]: PIXI.extras.BitmapText;
     [Container]: PIXI.Container;
@@ -227,7 +214,7 @@ declare namespace ReactPIXIFiber {
     [TilingSprite]: PIXI.extras.TilingSprite;
   }
 
-  /** The JSX element type. */
+  /** The custom JSX element type. */
   interface Element<T extends keyof InstanceMap, P = {}> extends React.ReactElement<P> {
     type: React.ComponentClass<P>;
     ref: React.Ref<InstanceMap[T]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,130 +1,261 @@
-import * as React from 'react';
 import * as PIXI from 'pixi.js';
 
-declare module 'react-pixi-fiber' {
+export = ReactPIXIFiber;
+
+declare namespace ReactPIXIFiber {
+
+  //
+  // Utility types.
+  //
 
   /**
-   * The set of object keys in T not in U.
-   *
-   * Attribution: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766:
+   * The difference of T and U.
+   * [attribution](https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766)
    */
-  export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-
+  type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
   /**
-   * An object with keys in T not in U.
-   *
-   * Attribution: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766:
+   * From T omit property with name U.
+   * [attribution](https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766)
    */
-  export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
-
+  type Omit<T, U extends keyof T> = Pick<T, Diff<keyof T, U>>;
   /** The shape of an object that has an optional `children` property of any type. */
   interface ObjectWithChildren { children?: any; }
-
   /** The shape of `T` without it's `children` property. */
-  export type Childless<T extends ObjectWithChildren> = Omit<T, 'children'>;
-
+  type Childless<T extends ObjectWithChildren> = Omit<T, 'children'>;
   /** The shape of a component that has an optional `children` property. */
-  export interface ChildrenProperties {
+  interface ChildrenProperties {
     children?: React.ReactNode;
   }
+  /** Produces a `Partial` form of any type defined in `ClassMap`, stripped of a `children` property. */
+  type PropertiesWithoutChildren<K extends keyof ClassMap> = Partial<Childless<ClassMap[K]>>;
+  /** Properties suitable for a display object */
+  type DisplayObjectProperties<K extends keyof ClassMap> = ClassAttributes<K> & PropertiesWithoutChildren<K>;
+  /** Properties suitable for a PIXI display object container */
+  type DisplayObjectContainerProperties<K extends keyof ClassMap> = DisplayObjectProperties<K> & ChildrenProperties;
+
+  //
+  // Component identifier types.
+  //
+
+  /** BitmapText component identifier type */
+  type BitmapText = 'BitmapText';
+  /** Container component identifier type */
+  type Container = 'Container';
+  /** Graphics component identifier type */
+  type Graphics = 'Graphics';
+  /** ParticleContainer component identifier type */
+  type ParticleContainer = 'ParticleContainer';
+  /** Sprite component identifier type */
+  type Sprite = 'Sprite';
+  /** Stage component identifier type */
+  type Stage = 'Stage';
+  /** Text component identifier type */
+  type Text = 'Text';
+  /** TilingSprite component identifier type */
+  type TilingSprite = 'TilingSprite';
+
+  //
+  //  Publically exported React element types that the reconciler can identifiy. You can
+  //  use these as you would other components.  This works iefei simlarly to how intrinsic elements
+  //  such as HTML and SVG elements work.
+  //
 
   /**
-   * A PIXI Component with no children.
+   * BitmapText React element type.
+   * @example const text = '';
+   * <BitmapText text={text} />
+   * @example React.createElement(BitmapText, { text })
+   * @example // equivalent to:
+   * React.createElement('BitmapText', { text })
    */
-  export type ChildlessComponent<T extends ObjectWithChildren> = Partial<Childless<T>>;
+  const BitmapText: BitmapText;
+  /**
+   * Container React element type.
+   * @example <Container />
+   * @example React.createElement(Container)
+   * @example // equivalent to:
+   * React.createElement('Container')
+   */
+  const Container: Container;
+  /**
+   * Graphics React element type.
+   * @example <Graphics />
+   * @example React.createElement(Graphics)
+   * @example // equivalent to:
+   * React.createElement('Graphics')
+   */
+  const Graphics: Graphics;
+  /**
+   * ParticleContainer React element type.
+   * @example <ParticleContainer />
+   * @example React.createElement(ParticleContainer)
+   * @example // equivalent to:
+   * React.createElement('ParticleContainer')
+   */
+  const ParticleContainer: ParticleContainer;
+  /**
+   * Sprite React element type.
+   * @example <Sprite />
+   * @example React.createElement(Sprite)
+   * @example // equivalent to:
+   * React.createElement('Sprite')
+   */
+  const Sprite: Sprite;
+  /**
+   * Stage React element type.
+   * @example <Stage width={100} height={100} />
+   * @example React.createElement(Stage)
+   * @example // equivalent to:
+   * React.createElement('Stage')
+   */
+  const Stage: Stage;
+  /**
+   * Text React element type.
+   * @example <Text />
+   * @example React.createElement(Text)
+   * @example // equivalent to:
+   * React.createElement('Text')
+  */
+  const Text: Text;
+  /**
+   * TilingSprite React element type.
+   * @example const texture = PIXI.Texture.fromImage(...);
+   * <TilingSprite texture={texture} />
+   * @example React.createElement(TilingSprite, { texture })
+   * @example // equivalent to:
+   * React.createElement('TilingSprite', { texture })
+   */
+  const TilingSprite: TilingSprite;
+
+  //
+  //  Component properties.
+  //  - `DisplayObjectProperties` do not have children.
+  //  - `DisplayObjectContainerProperties` can have children.
+  //
 
   /**
-   * A PIXI Component with children.
+   * BitmapText properties.
+   * @see http://pixijs.download/dev/docs/PIXI.extras.BitmapText.html
    */
-  export type Component<T extends ObjectWithChildren> = ChildlessComponent<T> & ChildrenProperties;
-
-  /** `BitmapText` component properties. */
-  export interface BitmapTextProperties extends ChildlessComponent<PIXI.extras.BitmapText> {
+  interface BitmapTextProperties extends DisplayObjectProperties<BitmapText> {
     text: string;
   }
-
   /**
-   * A component wrapper for `PIXI.extras.BitmapText`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.extras.BitmapText.html
+   * Container properties.
+   * @see http://pixijs.download/dev/docs/PIXI.Container.html
    */
-  export class BitmapText extends React.Component<BitmapTextProperties> {}
-
-  /** `Container` component properties. */
-  export interface ContainerProperties extends ChildlessComponent<PIXI.Container> {}
-
+  interface ContainerProperties extends DisplayObjectProperties<Container> {}
   /**
-   * A component wrapper for `PIXI.extras.BitmapText`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Container.html
+   * Graphics properties.
+   * @see http://pixijs.download/dev/docs/PIXI.Graphics.html
    */
-  export class Container extends React.Component<ContainerProperties> {}
-
-  /** `Graphics` component properties. */
-  export interface GraphicsProperties extends Component<PIXI.Graphics> {}
-
+  interface GraphicsProperties extends DisplayObjectContainerProperties<Graphics> {}
   /**
-   * A component wrapper for `PIXI.Graphics`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Graphics.html
+   * ParticleContainer properties.
+   * @see http://pixijs.download/dev/docs/PIXI.particles.ParticleContainer.html
    */
-  export class Graphics extends React.Component<GraphicsProperties> {}
-
-  /** `ParticleContainer` component properties. */
-  export interface ParticleContainerProperties extends ChildlessComponent<PIXI.particles.ParticleContainer> {}
-
+  interface ParticleContainerProperties extends DisplayObjectProperties<ParticleContainer> {}
   /**
-   * A component wrapper for `PIXI.particles.ParticleContainer`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.particles.ParticleContainer.html
+   * Sprite properties.
+   * @see http://pixijs.download/dev/docs/PIXI.Sprite.html
    */
-  export class ParticleContainer extends React.Component<TilingSpriteProperties> {}
-
-  /** `Sprite` component properties. */
-  export interface SpriteProperties extends ChildlessComponent<PIXI.Sprite> {}
-
+  interface SpriteProperties extends DisplayObjectProperties<Sprite> {}
   /**
-   * A component wrapper for `PIXI.Sprite`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Sprite.html
+   * Stage properties.
+   * @see http://pixijs.download/dev/docs/PIXI.Application.html
    */
-  export class Sprite extends React.Component<SpriteProperties> {}
-
-  /** `Text` component properties */
-  export interface TextProperties extends ChildlessComponent<PIXI.Text> {}
-
+  interface StageProperties extends DisplayObjectContainerProperties<Stage> {
+    backgroundColor?: number;
+  }
   /**
-   * A component wrapper for `PIXI.Text`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Text.html
+   * Text properties.
+   * @see http://pixijs.download/dev/docs/PIXI.Text.html
    */
-  export class Text extends React.Component<TextProperties> {}
-
-  /** `TilingSprite` component properties. */
-  export interface TilingSpriteProperties extends ChildlessComponent<PIXI.extras.TilingSprite> {
+  interface TextProperties extends DisplayObjectProperties<Text> {}
+  /**
+   * TilingSprite properties.
+   * @see http://pixijs.download/dev/docs/PIXI.extras.TilingSprite.html
+   */
+  interface TilingSpriteProperties extends DisplayObjectProperties<TilingSprite> {
     texture: PIXI.Texture;
   }
 
-  /**
-   * A component wrapper for `PIXI.extras.TilingSprite`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.extras.TilingSprite.html
-   */
-  export class TilingSprite extends React.Component<TilingSpriteProperties> {}
-
-  /** `Stage` component properties." */
-  export interface StageProperties extends Component<PIXI.Container> {
-    backgroundColor?: number;
-  }
-
-  /**
-   * A component wrapper for `PIXI.Application`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Application.html
-   */
-  export class Stage extends React.Component<StageProperties> {}
+  //
+  // Types required for augmenting the React module and the JSX namespace to support
+  // these custom elements.
+  //
 
   /** Custom React Reconciler render method. */
-  export function render(pixiElement: PIXI.DisplayObject | PIXI.DisplayObject[], stage: PIXI.Container, callback?: Function): void;
+  function render(pixiElement: PIXI.DisplayObject | PIXI.DisplayObject[], stage: PIXI.Container, callback?: Function): void;
 
+  /** Common class attributes. */
+  interface ClassAttributes<T extends keyof InstanceMap> extends React.ClassAttributes<InstanceMap[T]> {}
+
+  /** Map React element types to the PIXI object it's properties decorate. */
+  interface ClassMap {
+    [BitmapText]: PIXI.extras.BitmapText;
+    [Container]: PIXI.Container;
+    [Graphics]: PIXI.Graphics;
+    [ParticleContainer]: PIXI.particles.ParticleContainer;
+    [Sprite]: PIXI.Sprite;
+    [Stage]: PIXI.Container;
+    [Text]: PIXI.Text;
+    [TilingSprite]: PIXI.extras.TilingSprite;
+  }
+
+  /** Map React element types to the properties the component supports. */
+  interface PropertiesMap {
+    [BitmapText]: BitmapTextProperties;
+    [Container]: ContainerProperties;
+    [Graphics]: GraphicsProperties;
+    [ParticleContainer]: ParticleContainerProperties;
+    [Sprite]: SpriteProperties;
+    [Stage]: StageProperties;
+    [Text]: TextProperties;
+    [TilingSprite]: TilingSpriteProperties;
+  }
+
+  /** Map React element types reference type it emits. */
+  interface InstanceMap {
+    [BitmapText]: PIXI.extras.BitmapText;
+    [Container]: PIXI.Container;
+    [Graphics]: PIXI.Graphics;
+    [ParticleContainer]: PIXI.particles.ParticleContainer;
+    [Sprite]: PIXI.Sprite;
+    [Stage]: Element<Stage, any>;
+    [Text]: PIXI.Text;
+    [TilingSprite]: PIXI.extras.TilingSprite;
+  }
+
+  /** The JSX element type. */
+  interface Element<T extends keyof InstanceMap, P = {}> extends React.ReactElement<P> {
+    type: React.ComponentClass<P>;
+    ref: React.Ref<InstanceMap[T]>;
+  }
+}
+
+/**
+ * Augment the `react` module with a new `createElement` and `cloneElement` method supporting
+ * our custom components.
+ */
+declare module 'react' {
+  function createElement<T extends keyof ReactPIXIFiber.PropertiesMap, P extends ReactPIXIFiber.ClassAttributes<T>>(
+      type: T,
+      props?: P | null,
+      ...children: React.ReactNode[]): ReactPIXIFiber.Element<T, P>;
+
+  function cloneElement<T extends keyof ReactPIXIFiber.PropertiesMap, P extends ReactPIXIFiber.ClassAttributes<T>>(
+    element: ReactPIXIFiber.Element<T, P>,
+    props?: P,
+    ...children: PIXI.DisplayObject[]): ReactPIXIFiber.Element<T, P>;
+}
+
+/**
+ * Augment the global JSX namespace to include our custom component type map as
+ * intrinsic elements.
+ */
+declare global {
+  namespace JSX {
+    interface IntrinsicElements extends ReactPIXIFiber.PropertiesMap {}
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,12 +10,12 @@ declare namespace ReactPIXIFiber {
 
   /**
    * The difference of T and U.
-   * [attribution](https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766)
+   * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
    */
   type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
   /**
    * From T omit property with name U.
-   * [attribution](https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766)
+   * @see https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
    */
   type Omit<T, U extends keyof T> = Pick<T, Diff<keyof T, U>>;
   /** The shape of an object that has an optional `children` property of any type. */

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/pixi.js": "^4.4.0",
+    "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.0",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",

--- a/test/typescript/basic/usage.tsx
+++ b/test/typescript/basic/usage.tsx
@@ -28,8 +28,8 @@ const StageExample: React.SFC = () => (
       <BitmapText text="" />
     </Container>
     <Graphics />
-    <ParticleContainer texture={texture}>
-    <BitmapText text="" />
+    <ParticleContainer>
+      <BitmapText text="" />
     </ParticleContainer>
     <Sprite anchor={anchor} texture={texture} />
     <Text />

--- a/test/typescript/complex/app.tsx
+++ b/test/typescript/complex/app.tsx
@@ -5,9 +5,20 @@ import { Banner } from './banner';
 import { InteractiveBunny } from './interactive-bunny';
 import { FPSSpy } from './fps-spy';
 
+/** Example demo width and height. */
 const height = 450;
 const width = 600;
 
+/** A position within the stage */
+interface Position { x: number; y: number; }
+
+/** Initial bunny positions. */
+const initialBunnies: Position[] = [
+  { x: width / 3, y: height / 2 },
+  { x: 2 * width / 3, y: height / 2 },
+];
+
+/** Welcome message sequence. */
 const messages = [
   { text: 'Welcome!', delay: 2000, duration: 5000 },
   { text: 'Hover and drag to interact.', duration: 5000 },
@@ -15,44 +26,47 @@ const messages = [
   {},
 ];
 
-const inStage = (x: number, y: number) => (x >= 0 && x < width) && (y >= 0 && y < height);
-
-interface Position { x: number; y: number; }
-
-const isPosition = (p: Position | Partial<Position>): p is Position =>
-  typeof p.x === 'number' && typeof p.y === 'number';
-
 interface AppState {
+  /** The set of `Position`'s of `InteractiveBunny` being displayed. */
   bunnies: Position[];
 }
 
 class App extends React.Component<{}, AppState> {
   state: AppState = {
-    bunnies: [
-      { x: width / 3, y: height / 2 },
-      { x: 2 * width / 3, y: height / 2 },
-    ],
+    bunnies: [...initialBunnies],
   }
 
+  /** The `<span>` element presenting the current FPS */
   private fps: HTMLSpanElement | null = null;
 
-  updateFPSCounter = (fps: number) => {
+  /** Update the FPS counter by mutating the DOM directly to prevent needless re-renders. */
+  private updateFPSCounter = (fps: number) => {
     if (!this.fps) { return; }
     this.fps.innerText = fps.toString();
   }
 
-  updatePosition(index: number, value: Position | Partial<Position>) {
+  /**
+   * Update a bunny's position on the stage.
+   * - if type is `Partial<Position>`, the `value` will be merged with the current value.
+   * - if type is `Position`, the `value` will replace the current value.
+   */
+  private updatePosition(index: number, value: Partial<Position>) {
     const bunnies = [...this.state.bunnies];
-    bunnies[index] = isPosition(value) ? value : { ...bunnies[index], ...value };
+    bunnies[index] = { ...bunnies[index], ...value };
     this.setState({ bunnies });
   }
 
-  validateDrag = (index: number) => (x: number, y: number) => {
-    this.updatePosition(index, { x, y });
-    return inStage(x, y);
+  /** Validate the drag movement of an `InteractiveBunny`. */
+  private validateDrag = (index: number) => (x: number, y: number) => {
+    const valid = (x >= 0 && x < width) && (y >= 0 && y < height);
+    if (valid) {
+      this.updatePosition(index, { x, y });
+    }
+    return valid;
   }
 
-  handlePositionChange = (index: number, field: keyof Position) => (e: React.ChangeEvent<HTMLInputElement>) =>
+  /** Handle a position update from an `InteractiveBunny`. */
+  private handlePositionChange = (index: number, field: keyof Position) => (e: React.ChangeEvent<HTMLInputElement>) =>
     this.updatePosition(index, { [field]: e.target.valueAsNumber })
 
   render() {

--- a/test/typescript/complex/app.tsx
+++ b/test/typescript/complex/app.tsx
@@ -1,0 +1,114 @@
+import * as PIXI from 'pixi.js';
+import * as React from 'react';
+import { Stage, Sprite, Text } from 'react-pixi-fiber';
+import { Banner } from './banner';
+import { InteractiveBunny } from './interactive-bunny';
+import { FPSSpy } from './fps-spy';
+
+const height = 450;
+const width = 600;
+
+const messages = [
+  { text: 'Welcome!', delay: 2000, duration: 5000 },
+  { text: 'Hover and drag to interact.', duration: 5000 },
+  { text: 'Enjoy React PIXI Fiber!', duration: 5000 },
+  {},
+];
+
+const inStage = (x: number, y: number) => (x >= 0 && x < width) && (y >= 0 && y < height);
+
+interface Position { x: number; y: number; }
+
+const isPosition = (p: Position | Partial<Position>): p is Position =>
+  typeof p.x === 'number' && typeof p.y === 'number';
+
+interface AppState {
+  bunnies: Position[];
+}
+
+class App extends React.Component<{}, AppState> {
+  state: AppState = {
+    bunnies: [
+      { x: width / 3, y: height / 2 },
+      { x: 2 * width / 3, y: height / 2 },
+    ],
+  }
+
+  private fps: HTMLSpanElement | null = null;
+
+  updateFPSCounter = (fps: number) => {
+    if (!this.fps) { return; }
+    this.fps.innerText = fps.toString();
+  }
+
+  updatePosition(index: number, value: Position | Partial<Position>) {
+    const bunnies = [...this.state.bunnies];
+    bunnies[index] = isPosition(value) ? value : { ...bunnies[index], ...value };
+    this.setState({ bunnies });
+  }
+
+  validateDrag = (index: number) => (x: number, y: number) => {
+    this.updatePosition(index, { x, y });
+    return inStage(x, y);
+  }
+
+  handlePositionChange = (index: number, field: keyof Position) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    this.updatePosition(index, { [field]: e.target.valueAsNumber })
+
+  render() {
+    return (
+      <div>
+        <Stage
+          backgroundColor={0x1099bb}
+          height={height}
+          width={width}
+        >
+          {/* @TODO - officially expose `Stage's` inner `PIXI.Application` to parent. Until
+              then have spies who have access to it via `context.app` event changes to parent. */}
+          <FPSSpy onChange={this.updateFPSCounter} />
+          <Banner
+            messages={messages}
+            y={10}
+            maxWidth={width}
+          />
+          {this.state.bunnies.map((bunny, index) => (
+            <InteractiveBunny
+              x={bunny.x}
+              y={bunny.y}
+              validateDrag={this.validateDrag(index)}
+              key={index}
+            />
+          ))}
+        </Stage>
+
+        <div>
+          <p>FPS: <span ref={fps => { this.fps = fps; }}>N/A</span></p>
+          {this.state.bunnies.map((position, id) => (
+            <>
+              <p key={id}>Bunny {id + 1} position: ({position.x}, {position.y})</p>
+              {(['x', 'y'] as (keyof Position)[]).map(axis => (
+                <div>
+                  <label>{axis}</label>
+                  <input
+                    type="range"
+                    min={0}
+                    max={width}
+                    value={position[axis]}
+                    onChange={this.handlePositionChange(id, axis)}
+                  />
+                  <input
+                    type="number"
+                    min={0}
+                    max={width}
+                    value={position[axis]}
+                    onChange={this.handlePositionChange(id, axis)}
+                  />
+                </div>
+              ))}
+            </>
+          ))}
+        </div>
+      </div>
+    );
+  }
+}

--- a/test/typescript/complex/banner.tsx
+++ b/test/typescript/complex/banner.tsx
@@ -31,14 +31,16 @@ export class Banner extends StagedComponent<BannerProperties, BannerState> {
     this.start();
   }
 
-  async start() {
+  /** Start sequencing message display. */
+  private async start() {
     const { messages = [] } = this.props;
     for (const message of messages) {
       await this.showMessage(message);
     }
   }
 
-  async showMessage({ text, delay = 0, duration = 0 }: BannerMessage) {
+  /** Show a particular message with a delay and duration. */
+  private async showMessage({ text, delay = 0, duration = 0 }: BannerMessage) {
     return new Promise(resolve => {
       setTimeout(
         () => {

--- a/test/typescript/complex/banner.tsx
+++ b/test/typescript/complex/banner.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { CenteredText } from './centered-text';
+import { StagedComponent } from './lib';
+
+interface BannerMessage {
+  text?: string;
+  delay?: number;
+  duration?: number;
+}
+
+export interface BannerProperties {
+  messages?: BannerMessage[]
+  /** Max width of bounding box beginning at top/left of (x, y). */
+  maxWidth: number;
+  /** Position of top-left X-coordinate of bounding box. */
+  x?: number;
+  /** Position of top-left Y-coordinate of bounding box. */
+  y?: number;
+}
+
+interface BannerState {
+  text?: string;
+}
+
+export class Banner extends StagedComponent<BannerProperties, BannerState> {
+  state: BannerState = {
+    text: undefined,
+  };
+
+  componentDidMount() {
+    this.start();
+  }
+
+  async start() {
+    const { messages = [] } = this.props;
+    for (const message of messages) {
+      await this.showMessage(message);
+    }
+  }
+
+  async showMessage({ text, delay = 0, duration = 0 }: BannerMessage) {
+    return new Promise(resolve => {
+      setTimeout(
+        () => {
+          this.setState({ text });
+          setTimeout(resolve, duration);
+        },
+        delay,
+      );
+    });
+  }
+
+  render() {
+    return <CenteredText text={this.state.text} {...this.props} />;
+  }
+}

--- a/test/typescript/complex/bunny.tsx
+++ b/test/typescript/complex/bunny.tsx
@@ -1,0 +1,95 @@
+import * as PIXI from 'pixi.js';
+import * as React from 'react';
+import { Sprite } from 'react-pixi-fiber';
+import { StagedComponent } from './lib';
+
+const bunny = "https://i.imgur.com/IaUrttj.png";
+const centerAnchor = new PIXI.ObservablePoint(() => {}, undefined, 0.5, 0.5);
+
+export interface BunnyProperties {
+  /* X position. (default: 0) */
+  x?: number;
+  /** Y position. (default: 0) */
+  y?: number;
+  /** Rotation. (default: 0) */
+  rotation?: number;
+  /** Alpha. (default: 1) */
+  alpha?: number;
+  /** Event fired when sprite instance is created. */
+  onCreated?: (instance: PIXI.Sprite) => any;
+  /** Event fired when sprite instance is destroyed. */
+  onDestroyed?: (instance: PIXI.Sprite) => any;
+  /** Event fired when sprite instance is hovered in. */
+  onHoverIn?: (instance: PIXI.Sprite) => any;
+  /** Event fired when sprite instance is hovered out. */
+  onHoverOut?: (instance: PIXI.Sprite) => any;
+  /** Event fired when sprite instance is dragged. */
+  onDrag?: (instance: PIXI.Sprite, x: number, y: number) => any;
+}
+
+export class Bunny extends StagedComponent<BunnyProperties> {
+  /** Internal PIXI.Sprite instance. */
+  private sprite: PIXI.Sprite | null = null;
+
+  /** Flag set when dragging. */
+  private dragging: boolean = false;
+
+  componentDidMount() {
+    this.configureSprite();
+    this.emitCreated();
+  }
+
+  componentWillUnmount() {
+    this.emitDestroyed();
+  }
+
+  /** Emit onCreated. */
+  private emitCreated = () => this.sprite && this.props.onCreated && this.props.onCreated(this.sprite);
+
+  /** Emit onDestroyed. */
+  private emitDestroyed = () => this.sprite && this.props.onDestroyed && this.props.onDestroyed(this.sprite);
+
+  /** Emit onHoverIn. */
+  private emitHoverIn = () => this.sprite && this.props.onHoverIn && this.props.onHoverIn(this.sprite)
+
+  /** Emit onHoverOut. */
+  private emitHoverOut = () => this.sprite && this.props.onHoverOut && this.props.onHoverOut(this.sprite);
+
+  /** Emit onDrag. */
+  private emitDrag = (x: number, y: number) => this.sprite && this.props.onDrag && this.props.onDrag(this.sprite, x, y);
+
+  /** When dragging starts, set the dragging flag. */
+  private dragStart = () => { this.dragging = true; }
+
+  /** When dragging, emit a drag event. */
+  private dragMove = (e: PIXI.interaction.InteractionEvent) => this.dragging && this.emitDrag(e.data.global.x, e.data.global.y);
+
+  /** When dragging stops, unset the dragging flag.. */
+  private dragEnd = () => { this.dragging = false; }
+
+  /** Configure the sprite. */
+  private configureSprite() {
+    if (!this.sprite) { return; }
+    this.sprite
+      .on('mouseover', this.emitHoverIn)
+      .on('mouseout', this.emitHoverOut)
+      .on('mousedown', this.dragStart)
+      .on('touchstart', this.dragStart)
+      .on('mousemove', this.dragMove)
+      .on('touchmove', this.dragMove)
+      .on('mouseup', this.dragEnd)
+      .on('touchend', this.dragEnd);
+  }
+
+  render() {
+    return (
+      <Sprite
+        ref={sprite => { this.sprite = sprite; }}
+        anchor={centerAnchor}
+        texture={PIXI.Texture.fromImage(bunny)}
+        interactive={true}
+        {...this.props}
+      />
+    );
+  }
+}

--- a/test/typescript/complex/bunny.tsx
+++ b/test/typescript/complex/bunny.tsx
@@ -24,7 +24,7 @@ export interface BunnyProperties {
   /** Event fired when sprite instance is hovered out. */
   onHoverOut?: (instance: PIXI.Sprite) => any;
   /** Event fired when sprite instance is dragged. */
-  onDrag?: (instance: PIXI.Sprite, x: number, y: number) => any;
+  onDrag?: (x: number, y: number, instance: PIXI.Sprite) => any;
 }
 
 export class Bunny extends StagedComponent<BunnyProperties> {
@@ -56,7 +56,7 @@ export class Bunny extends StagedComponent<BunnyProperties> {
   private emitHoverOut = () => this.sprite && this.props.onHoverOut && this.props.onHoverOut(this.sprite);
 
   /** Emit onDrag. */
-  private emitDrag = (x: number, y: number) => this.sprite && this.props.onDrag && this.props.onDrag(this.sprite, x, y);
+  private emitDrag = (x: number, y: number) => this.sprite && this.props.onDrag && this.props.onDrag(x, y, this.sprite);
 
   /** When dragging starts, set the dragging flag. */
   private dragStart = () => { this.dragging = true; }

--- a/test/typescript/complex/centered-text.tsx
+++ b/test/typescript/complex/centered-text.tsx
@@ -1,0 +1,64 @@
+import * as PIXI from 'pixi.js';
+import * as React from 'react';
+import { Text } from 'react-pixi-fiber';
+import { StagedComponent } from './lib';
+
+export interface CenteredTextProperties {
+  /** Optional text. */
+  text?: string;
+  /** Max width of bounding box beginning at top/left of (x, y). */
+  maxWidth: number;
+  /** Position of top-left X-coordinate of bounding box. */
+  x?: number;
+  /** Position of top-left Y-coordinate of bounding box. */
+  y?: number;
+}
+
+interface CenteredTextState {
+  /** The width of the text being displayed. */
+  textWidth: number;
+}
+
+export class CenteredText extends StagedComponent<CenteredTextProperties, CenteredTextState> {
+  state: CenteredTextState = {
+    textWidth: 0,
+  };
+
+  /** Internal PIXI.Text instance. */
+  private text: PIXI.Text | null = null;
+
+  private textChanged: boolean = false;
+
+  componentDidMount() {
+    this.setTextWidth();
+  }
+
+  componentWillReceiveProps(nextProps: CenteredTextProperties) {
+    if (nextProps.text !== this.props.text) {
+      this.textChanged = true;
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.textChanged) {
+      this.setTextWidth();
+      this.textChanged = false;
+    }
+  }
+
+  setTextWidth() {
+    if (!this.text) { return; }
+    this.setState({ textWidth: this.text.width });
+  }
+
+  render() {
+    return (
+      <Text
+        ref={text => { this.text = text; }}
+        text={this.props.text}
+        x={(this.props.x || 0) + (this.props.maxWidth / 2) - (this.state.textWidth / 2)}
+        y={this.props.y || 0}
+      />
+    );
+  }
+}

--- a/test/typescript/complex/centered-text.tsx
+++ b/test/typescript/complex/centered-text.tsx
@@ -30,23 +30,27 @@ export class CenteredText extends StagedComponent<CenteredTextProperties, Center
   private textChanged: boolean = false;
 
   componentDidMount() {
+    // set the initial text width
     this.setTextWidth();
   }
 
   componentWillReceiveProps(nextProps: CenteredTextProperties) {
+    // text width is changing
     if (nextProps.text !== this.props.text) {
       this.textChanged = true;
     }
   }
 
   componentDidUpdate() {
+    // update text width if text changed
     if (this.textChanged) {
       this.setTextWidth();
       this.textChanged = false;
     }
   }
 
-  setTextWidth() {
+  /** Set the width of the text for centering. */
+  private setTextWidth() {
     if (!this.text) { return; }
     this.setState({ textWidth: this.text.width });
   }

--- a/test/typescript/complex/fps-spy.tsx
+++ b/test/typescript/complex/fps-spy.tsx
@@ -2,18 +2,21 @@ import * as React from 'react';
 import { StagedComponent } from './lib';
 
 export interface FPSSpyProperties {
+  /** Handle FPS change event. */
   onChange: (fps: number) => void;
 }
 
 export class FPSSpy extends StagedComponent<FPSSpyProperties> {
-  fps?: number = undefined;
+  /** The last _rounded_ `PIXI.ticker.Ticker`'s `FPS` value. */
+  private fps?: number = undefined;
 
   componentDidMount() {
     if (!this.props.onChange) { return; }
     this.context.app.ticker.add(this.emitChange);
   }
 
-  emitChange = () => {
+  /** Emit if the _rounded_ value of `PIXI.ticker.Ticker`'s `FPS` property changed. */
+  private emitChange = () => {
     const fps = Math.round(this.context.app.ticker.FPS);
     if (this.props.onChange && this.fps !== fps) {
       this.fps = fps;

--- a/test/typescript/complex/fps-spy.tsx
+++ b/test/typescript/complex/fps-spy.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { StagedComponent } from './lib';
+
+export interface FPSSpyProperties {
+  onChange: (fps: number) => void;
+}
+
+export class FPSSpy extends StagedComponent<FPSSpyProperties> {
+  fps?: number = undefined;
+
+  componentDidMount() {
+    if (!this.props.onChange) { return; }
+    this.context.app.ticker.add(this.emitChange);
+  }
+
+  emitChange = () => {
+    const fps = Math.round(this.context.app.ticker.FPS);
+    if (this.props.onChange && this.fps !== fps) {
+      this.fps = fps;
+      this.props.onChange(this.fps);
+    }
+  };
+
+  render() {
+    return null;
+  }
+}

--- a/test/typescript/complex/interactive-bunny.tsx
+++ b/test/typescript/complex/interactive-bunny.tsx
@@ -1,4 +1,3 @@
-import * as PIXI from 'pixi.js';
 import * as React from 'react';
 import { Bunny } from './bunny';
 import { StagedComponent } from './lib';
@@ -41,11 +40,11 @@ export class InteractiveBunny extends StagedComponent<InteractiveBunnyProperties
     }
   }
 
-  private handleHoverIn = (sprite: PIXI.Sprite) => this.setState({ alpha: BUNNY_HIGHLIGHT });
+  private handleHoverIn = () => this.setState({ alpha: BUNNY_HIGHLIGHT });
 
-  private handleHoverOut = (sprite: PIXI.Sprite) => this.setState({ alpha: BUNNY_NORMAL });
+  private handleHoverOut = () => this.setState({ alpha: BUNNY_NORMAL });
 
-  private handleDrag = (sprite: PIXI.Sprite, x: number, y: number) =>
+  private handleDrag = (x: number, y: number) =>
     (this.props.validateDrag ? this.props.validateDrag(x, y) : true) && this.setState({ x, y })
 
   render() {

--- a/test/typescript/complex/interactive-bunny.tsx
+++ b/test/typescript/complex/interactive-bunny.tsx
@@ -1,0 +1,61 @@
+import * as PIXI from 'pixi.js';
+import * as React from 'react';
+import { Bunny } from './bunny';
+import { StagedComponent } from './lib';
+
+const BUNNY_NORMAL = 0.5;
+const BUNNY_HIGHLIGHT = 1;
+const BUNNY_ROTATION = 0;
+const BUNNY_STARTX = 0;
+const BUNNY_STARTY = 0;
+
+export interface InteractiveBunnyProperties {
+  /** Optional starting x position */
+  x?: number;
+  /** Optional starting y position */
+  y?: number;
+  /** Optional drag position validation */
+  validateDrag?: (x: number, y: number) => boolean;
+}
+
+interface InteractiveBunnyState {
+  /** Alpha value */
+  alpha: number;
+  /** X position */
+  x: number;
+  /** Y position */
+  y: number;
+}
+
+export class InteractiveBunny extends StagedComponent<InteractiveBunnyProperties, InteractiveBunnyState> {
+  state: Readonly<InteractiveBunnyState> = {
+    alpha: BUNNY_NORMAL,
+    x: this.props.x || BUNNY_STARTX,
+    y: this.props.y || BUNNY_STARTY,
+  };
+
+  componentWillReceiveProps(nextProps: InteractiveBunnyProperties) {
+    if ((nextProps.x !== this.props.x && nextProps.x !== this.state.x)
+    || (nextProps.y !== this.props.y && nextProps.y !== this.state.y)) {
+      this.setState({ x: nextProps.x || 0, y: nextProps.y || 0 });
+    }
+  }
+
+  private handleHoverIn = (sprite: PIXI.Sprite) => this.setState({ alpha: BUNNY_HIGHLIGHT });
+
+  private handleHoverOut = (sprite: PIXI.Sprite) => this.setState({ alpha: BUNNY_NORMAL });
+
+  private handleDrag = (sprite: PIXI.Sprite, x: number, y: number) =>
+    (this.props.validateDrag ? this.props.validateDrag(x, y) : true) && this.setState({ x, y })
+
+  render() {
+    return (
+      <Bunny
+        onHoverIn={this.handleHoverIn}
+        onDrag={this.handleDrag}
+        onHoverOut={this.handleHoverOut}
+        {...this.state}
+      />
+    );
+  }
+}

--- a/test/typescript/complex/lib.tsx
+++ b/test/typescript/complex/lib.tsx
@@ -1,0 +1,80 @@
+import * as PIXI from 'pixi.js';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+
+export const contextTypes = { app: PropTypes.object };
+
+export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
+
+/**
+ * An object with keys in T not in U.
+ *
+ * Attribution: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766:
+ */
+export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+
+/** The structure of a staged component's context. */
+export interface StagedComponentContext {
+  app: PIXI.Application;
+}
+
+/** a React component with context configured and typed. */
+export abstract class StagedComponent<P = {}, S = {}> extends React.Component<P, S> {
+  ref?: (i: P) => any;
+  static contextTypes = contextTypes;
+  context: StagedComponentContext = {} as any as StagedComponentContext;
+}
+
+/** A React stateless funtional component with typed context.  To configure, use the `lift` or `connect` HoC's. */
+export interface StagedStatlessComponent<P = {}> {
+  (props: P & { children?: React.ReactNode }, context: StagedComponentContext): React.ReactElement<any> | null;
+  propTypes?: React.ValidationMap<P>;
+  contextTypes?: React.ValidationMap<any>;
+  defaultProps?: Partial<P>;
+  displayName?: string;
+}
+
+/** A shorthand alias for StagedStatelessComponent<P>. */
+export type StagedSFC<P = {}> = StagedStatlessComponent<P>;
+
+/**
+ * Project a React stateless functional component to a PIXI statless functional component.
+ *
+ * @example
+ * const Comp = lift((props, context) =>  <Sprite />);
+ */
+export function lift<P, C extends StagedComponentContext = StagedComponentContext>(fn: (props: P, context: C) => JSX.Element): StagedSFC<P> {
+  const Comp = fn as any as StagedSFC<P>;
+  Comp.contextTypes = contextTypes;
+  return Comp;
+}
+
+/** Connect definition predicate */
+export interface EnhancerWithOwnProperties<C, P extends C> {
+  (component: React.ComponentClass<P> | React.StatelessComponent<P>): React.ComponentClass<Omit<P, keyof C>>;
+}
+
+/**
+ * Connect the context to a React component via property mapping.
+ *
+ * @example
+ * interface CompProperties {}
+ *
+ * interface CompContextProperties { app: PIXI.Application; }
+ *
+ * interface CompMergedProperties extends CompProperties, CompContextProperties {}
+ *
+ * const Comp: StagedSFC<CompMergedProperties> = (props, context) =>  <Sprite />;
+ *
+ * const mapContextToProps = (context: StagedComponentContext): CompContextProperties => ({ app: context.app });
+ *
+ * connect<CompContextProperties, CompMergedProperties>(mapContextToProps)(Comp);
+ */
+export function connect<C extends object, P extends C>(fn: (context: StagedComponentContext) => C): EnhancerWithOwnProperties<C, P> {
+  return (Component: React.ComponentClass<P> | React.StatelessComponent<P>): React.ComponentClass<Omit<P, keyof C>> =>
+    class WrappedComponent extends StagedComponent<P> {
+      render() {
+        return <Component {...this.props} {...fn(this.context)} />;
+      }
+    } as any as React.ComponentClass<Omit<P, keyof C>>;
+}

--- a/test/typescript/complex/lib.tsx
+++ b/test/typescript/complex/lib.tsx
@@ -26,7 +26,7 @@ export abstract class StagedComponent<P = {}, S = {}> extends React.Component<P,
 }
 
 /** A React stateless funtional component with typed context.  To configure, use the `lift` or `connect` HoC's. */
-export interface StagedStatlessComponent<P = {}> {
+export interface StagedStatelessComponent<P = {}> {
   (props: P & { children?: React.ReactNode }, context: StagedComponentContext): React.ReactElement<any> | null;
   propTypes?: React.ValidationMap<P>;
   contextTypes?: React.ValidationMap<any>;
@@ -35,7 +35,7 @@ export interface StagedStatlessComponent<P = {}> {
 }
 
 /** A shorthand alias for StagedStatelessComponent<P>. */
-export type StagedSFC<P = {}> = StagedStatlessComponent<P>;
+export type StagedSFC<P = {}> = StagedStatelessComponent<P>;
 
 /**
  * Project a React stateless functional component to a PIXI statless functional component.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@types/pixi.js/-/pixi.js-4.7.0.tgz#df14c36b2d1e264668d46f00d0aee691016a7cfe"
 
+"@types/prop-types@^15.5.2":
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"
+
 "@types/react@^16.0.0":
   version "16.0.36"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.36.tgz#ceb5639013bdb92a94147883052e69bb2c22c69b"


### PR DESCRIPTION
As I got into working with `react-pixi-fiber` I realized the TypeScript definitions were wrong-headed: they attempt to define the components as what they appear to be to a consumer, rather than what they are.  This causes a variety issues when doing anything non-trivial with the library, such as the inability to get proper typing on ref's, since for all components other than Stage, ref returns it's PIXI instance instead of itself.

This PR addresses these weaknesses by defining the library as it is implemented, which is the correct approach.  There is no way to split this PR into smaller pieces as the issue was fundamental to the definition approach, and the examples are necessary to demonstrate exercising the definitions with non-trivial use.

Changes include:

- Components are exported element type strings that the custom reconciler recognizes
- Component refs are properly typed
- React module augmented to provide supporting `createElement` and `cloneElement` methods
- JSX global namespace augmented to provide support for these new element types
- TypeScript tests greatly expanded to include a complex example demonstrating non-trivial usage of the library, including:
  - using ref's
  - attaching to instance events
  - composition
  - spying on the stage (see FPSSpy: whats going on in the application is officially opaque to parents unless a spy is injected who has access to the PIXI.Application context- this is something that can be trivially exposed by Stage and would prevent this type of pattern)
  - controlling elements on the stage from DOM elements
  - updating staged component values on prop updates