### PR TITLE
Tweak prop handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
     "react",
     "prettier"
   ],
+  "parser": "babel-eslint",
   "parserOptions": {
     "sourceType": "module",
     "ecmaFeatures": {

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "printWidth": 120,
+  "proseWrap": "preserve",
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added parser for PIXI.Point-like props - Point-like DisplayObject members can now be assigned using string, number, array and Point/ObservablePoint
+
 ### Changed
 - Changed `<Stage />` to pass `options` prop to `PIXI.Application`
 - Changed `<Stage />` to pass not consumed props to rendered canvas
+- Changed inconsistent usage of reconciler config functions to use regular functions instead of anonymous arrow functions
+- Changed `PIXI.DisplayObject` members handling when passed as props - `undefined` values will now be replaced with default values if default defined
+
+### Fixed
+- Fixed deprecated usage of `PIXI.BitmapText` to `PIXI.extras.BitmapText`
 
 ### Removed
 - Removed `backgroundColor` prop from `<Stage />`

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This example will render [`PIXI.Text`] object into a [Root Container] of PIXI Ap
 
 ## Installing
 
-The current version assumes [React](https://github.com/facebook/react) >16.0.0 and [PixiJS] >4.4.0
+The current version assumes [React] >16.0.0 and [PixiJS] >4.4.0
 
     yarn add react-pixi-fiber
 
@@ -141,6 +141,10 @@ Renders [`PIXI.Container`].
 
 Renders [`PIXI.Graphics`].
 
+#### `<ParticleContainer />`
+
+Renders [`PIXI.particles.ParticleContainer`].
+
 #### `<Sprite />`
 
 Renders [`PIXI.Sprite`].
@@ -156,6 +160,24 @@ Renders [`PIXI.Text`].
 #### `<BitmapText />`
 
 Renders [`PIXI.extras.BitmapText`].
+
+### Props
+
+[Similarly](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html) to ReactDOM in React 16, 
+ReactPixiFiber is not ignoring unknown [`PIXI.DisplayObject`] members – they are all passed through. You can read 
+more about [Unknown Prop Warning](https://reactjs.org/warnings/unknown-prop.html)  in ReactDOM, however 
+ReactPixiFiber will not warn you about unknown members. 
+
+#### Setting values for Point and ObservablePoint types
+
+For setting properties on PixiJS types that are either [`PIXI.Point`]s or [`PIXI.ObservablePoint`]s you can use either 
+and array of integers or a comma-separated string of integers in the following forms: `[x,y]`, `"x,y"`, `[i]`, `"i"`. 
+
+In the case where two integers are provided, the first will be applied to the `x` coordinate and the second will be 
+applied to the `y` coordinate. In the case where a single integer if provided, it will be applied to both coordinates.
+
+You can still create your own PIXI `Point` or `ObservablePoint` objects and assign them directly to the property. 
+These won't actually replace the property but they will be applied using the original object's `.copy()` method.
 
 
 ## Testing
@@ -214,18 +236,23 @@ For helping me understand how to build an actual renderer.
 
 On which this renderer was initially based.
 
-### [React](https://github.com/facebook/react) Contributors
+### [React] Contributors
 
 For making an awesome project structure and documentation that is used in similar fashon here.
 
 
 [PixiJS]: https://github.com/pixijs/pixi.js
-[`react-pixi`]: https://github.com/Izzimach/react-pixi
-[`PIXI.Application`]: http://pixijs.download/release/docs/PIXI.Application.html
+[React]: https://github.com/facebook/react
 [Root Container]: http://pixijs.download/release/docs/PIXI.Application.html#stage
+[`PIXI.Application`]: http://pixijs.download/release/docs/PIXI.Application.html
 [`PIXI.Container`]: http://pixijs.download/release/docs/PIXI.Container.html
-[`PIXI.Graphics`]: http://pixijs.download/release/docs/PIXI.Graphics.html
-[`PIXI.Sprite`]: http://pixijs.download/release/docs/PIXI.Sprite.html
-[`PIXI.extras.TilingSprite`]: http://pixijs.download/release/docs/PIXI.extras.TilingSprite.html
-[`PIXI.Text`]: http://pixijs.download/release/docs/PIXI.Text.html
+[`PIXI.DisplayObject`]: http://pixijs.download/release/docs/PIXI.DisplayObject.html 
 [`PIXI.extras.BitmapText`]: http://pixijs.download/release/docs/PIXI.extras.BitmapText.html
+[`PIXI.extras.TilingSprite`]: http://pixijs.download/release/docs/PIXI.extras.TilingSprite.html
+[`PIXI.Graphics`]: http://pixijs.download/release/docs/PIXI.Graphics.html
+[`PIXI.ObservablePoint`]: http://pixijs.download/release/docs/PIXI.ObservablePoint.html
+[`PIXI.particles.ParticleContainer`]: http://pixijs.download/release/docs/PIXI.particles.ParticleContainer.html
+[`PIXI.Point`]: http://pixijs.download/release/docs/PIXI.Point.html
+[`PIXI.Sprite`]: http://pixijs.download/release/docs/PIXI.Sprite.html
+[`PIXI.Text`]: http://pixijs.download/release/docs/PIXI.Text.html
+[`react-pixi`]: https://github.com/Izzimach/react-pixi

--- a/examples/src/App/App.js
+++ b/examples/src/App/App.js
@@ -8,33 +8,39 @@ import BunnyExample from "../BunnyExample";
 import BunnymarkExample from "../BunnymarkExample";
 import CanvasPropsExample from "../CanvasPropsExample";
 import ClickExample from "../ClickExample";
+import PointsExample from "../PointsExample/PointsExample";
 
 const examples = [
   {
     name: "Application Options",
     slug: "applicationoptions",
-    component: ApplicationOptionsExample
+    component: ApplicationOptionsExample,
   },
   {
     name: "Bunny",
     slug: "bunny",
-    component: BunnyExample
+    component: BunnyExample,
   },
   {
     name: "Bunnymark",
     slug: "bunnymark",
-    component: BunnymarkExample
+    component: BunnymarkExample,
   },
   {
     name: "Canvas Props",
     slug: "canvasprops",
-    component: CanvasPropsExample
+    component: CanvasPropsExample,
   },
   {
     name: "Click",
     slug: "click",
-    component: ClickExample
-  }
+    component: ClickExample,
+  },
+  {
+    name: "Point-like props",
+    slug: "points",
+    component: PointsExample,
+  },
 ];
 
 class App extends Component {
@@ -47,18 +53,9 @@ class App extends Component {
         </header>
         <div className="App-intro">
           <Switch>
-            <Route
-              exact
-              path="/"
-              render={props => <ExampleList {...props} examples={examples} />}
-            />
+            <Route exact path="/" render={props => <ExampleList {...props} examples={examples} />} />
             {examples.map(example => (
-              <Route
-                key={example.slug}
-                exact
-                path={`/${example.slug}`}
-                component={example.component}
-              />
+              <Route key={example.slug} exact path={`/${example.slug}`} component={example.component} />
             ))}
           </Switch>
         </div>

--- a/examples/src/ApplicationOptionsExample/index.js
+++ b/examples/src/ApplicationOptionsExample/index.js
@@ -2,15 +2,15 @@ import React, { Component } from "react";
 import { Stage } from "react-pixi-fiber";
 import Bunny from "./../Bunny";
 
-const options = {
+const OPTIONS = {
   backgroundColor: 0x10bb99,
-  view: document.querySelector("#id_preexisting_canvas")
+  view: document.querySelector("#id_preexisting_canvas"),
 };
 
 class ApplicationOptionsExample extends Component {
   render() {
     return (
-      <Stage width={800} height={600} options={options}>
+      <Stage width={800} height={600} options={OPTIONS}>
         <Bunny x={400} y={300} />
       </Stage>
     );

--- a/examples/src/Bunny/index.js
+++ b/examples/src/Bunny/index.js
@@ -6,13 +6,7 @@ import bunny from "./bunny.png";
 const centerAnchor = new PIXI.Point(0.5, 0.5);
 
 function Bunny(props) {
-  return (
-    <Sprite
-      anchor={centerAnchor}
-      texture={PIXI.Texture.fromImage(bunny)}
-      {...props}
-    />
-  );
+  return <Sprite anchor={centerAnchor} texture={PIXI.Texture.fromImage(bunny)} {...props} />;
 }
 
 export default Bunny;

--- a/examples/src/BunnyExample/RotatingBunny.js
+++ b/examples/src/BunnyExample/RotatingBunny.js
@@ -5,7 +5,7 @@ import Bunny from "../Bunny";
 // http://pixijs.io/examples/#/basics/basic.js
 class RotatingBunny extends Component {
   state = {
-    rotation: 0
+    rotation: 0,
   };
 
   componentDidMount() {
@@ -22,7 +22,7 @@ class RotatingBunny extends Component {
     // creates frame-independent tranformation
     this.setState(state => ({
       ...state,
-      rotation: state.rotation + 0.1 * delta
+      rotation: state.rotation + 0.1 * delta,
     }));
   };
 
@@ -31,7 +31,7 @@ class RotatingBunny extends Component {
   }
 }
 RotatingBunny.contextTypes = {
-  app: PropTypes.object
+  app: PropTypes.object,
 };
 
 export default RotatingBunny;

--- a/examples/src/BunnyExample/index.js
+++ b/examples/src/BunnyExample/index.js
@@ -2,10 +2,14 @@ import React, { Component } from "react";
 import { Stage } from "react-pixi-fiber";
 import RotatingBunny from "./RotatingBunny";
 
+const OPTIONS = {
+  backgroundColor: 0x1099bb,
+};
+
 class BunnyExample extends Component {
   render() {
     return (
-      <Stage width={800} height={600} backgroundColor={0x1099bb}>
+      <Stage width={800} height={600} options={OPTIONS}>
         <RotatingBunny x={400} y={300} />
       </Stage>
     );

--- a/examples/src/BunnymarkExample/Bunnymark.js
+++ b/examples/src/BunnymarkExample/Bunnymark.js
@@ -19,7 +19,7 @@ const particleContainerProperties = {
   position: true,
   rotation: false,
   uvs: false,
-  tint: false
+  tint: false,
 };
 
 const generateBunny = texture => ({
@@ -27,7 +27,7 @@ const generateBunny = texture => ({
   speedY: Math.random() * 10 - 5,
   texture: texture,
   x: 0,
-  y: 0
+  y: 0,
 });
 
 const moveBunny = bunny => {
@@ -63,7 +63,7 @@ class Bunnymark extends Component {
   state = {
     bunnys: [],
     currentTexture: 0,
-    isAdding: false
+    isAdding: false,
   };
 
   componentDidMount() {
@@ -71,32 +71,17 @@ class Bunnymark extends Component {
     document.body.appendChild(this.stats.domElement);
 
     const bunnyTextures = new PIXI.Texture.fromImage(bunnys);
-    const bunny1 = new PIXI.Texture(
-      bunnyTextures.baseTexture,
-      new PIXI.Rectangle(2, 47, 26, 37)
-    );
-    const bunny2 = new PIXI.Texture(
-      bunnyTextures.baseTexture,
-      new PIXI.Rectangle(2, 86, 26, 37)
-    );
-    const bunny3 = new PIXI.Texture(
-      bunnyTextures.baseTexture,
-      new PIXI.Rectangle(2, 125, 26, 37)
-    );
-    const bunny4 = new PIXI.Texture(
-      bunnyTextures.baseTexture,
-      new PIXI.Rectangle(2, 164, 26, 37)
-    );
-    const bunny5 = new PIXI.Texture(
-      bunnyTextures.baseTexture,
-      new PIXI.Rectangle(2, 2, 26, 37)
-    );
+    const bunny1 = new PIXI.Texture(bunnyTextures.baseTexture, new PIXI.Rectangle(2, 47, 26, 37));
+    const bunny2 = new PIXI.Texture(bunnyTextures.baseTexture, new PIXI.Rectangle(2, 86, 26, 37));
+    const bunny3 = new PIXI.Texture(bunnyTextures.baseTexture, new PIXI.Rectangle(2, 125, 26, 37));
+    const bunny4 = new PIXI.Texture(bunnyTextures.baseTexture, new PIXI.Rectangle(2, 164, 26, 37));
+    const bunny5 = new PIXI.Texture(bunnyTextures.baseTexture, new PIXI.Rectangle(2, 2, 26, 37));
 
     this.bunnyTextures = [bunny1, bunny2, bunny3, bunny4, bunny5];
     const currentTexture = 2;
     this.setState({
       bunnys: [generateBunny(currentTexture), generateBunny(currentTexture)],
-      currentTexture: currentTexture
+      currentTexture: currentTexture,
     });
 
     this.context.app.ticker.add(this.animate);
@@ -131,7 +116,7 @@ class Bunnymark extends Component {
 
   handlePointerUp = () => {
     this.setState(state => ({
-      currentTexture: (state.currentTexture + 1) % 5
+      currentTexture: (state.currentTexture + 1) % 5,
     }));
 
     this.setState({ isAdding: false });
@@ -142,26 +127,12 @@ class Bunnymark extends Component {
 
     return (
       <Fragment>
-        <ParticleContainer
-          maxSize={maxSize}
-          properties={particleContainerProperties}
-        >
+        <ParticleContainer maxSize={maxSize} properties={particleContainerProperties}>
           {bunnys.map((bunny, i) => (
-            <Sprite
-              key={i}
-              anchor={bunnyAnchor}
-              texture={this.bunnyTextures[bunny.texture]}
-              x={bunny.x}
-              y={bunny.y}
-            />
+            <Sprite key={i} anchor={bunnyAnchor} texture={this.bunnyTextures[bunny.texture]} x={bunny.x} y={bunny.y} />
           ))}
         </ParticleContainer>
-        <Text
-          text={`${bunnys.length} BUNNIES`}
-          style={{ fill: 0xffff00, fontSize: 14 }}
-          x={5}
-          y={5}
-        />
+        <Text text={`${bunnys.length} BUNNIES`} style={{ fill: 0xffff00, fontSize: 14 }} x={5} y={5} />
         {/* ParticleContainer and its children cannot be interactive
             so here's a clickable hit area */}
         <Sprite
@@ -177,7 +148,7 @@ class Bunnymark extends Component {
   }
 }
 Bunnymark.contextTypes = {
-  app: PropTypes.object
+  app: PropTypes.object,
 };
 
 export default Bunnymark;

--- a/examples/src/BunnymarkExample/index.js
+++ b/examples/src/BunnymarkExample/index.js
@@ -3,17 +3,21 @@ import PropTypes from "prop-types";
 import { Stage } from "react-pixi-fiber";
 import Bunnymark from "./Bunnymark";
 
+const OPTIONS = {
+  backgroundColor: 0x1099bb,
+};
+
 class BunnymarkExample extends Component {
   render() {
     return (
-      <Stage width={800} height={600} backgroundColor={0x1099bb}>
+      <Stage width={800} height={600} options={OPTIONS}>
         <Bunnymark />
       </Stage>
     );
   }
 }
 BunnymarkExample.contextTypes = {
-  app: PropTypes.object
+  app: PropTypes.object,
 };
 
 export default BunnymarkExample;

--- a/examples/src/CanvasPropsExample/index.js
+++ b/examples/src/CanvasPropsExample/index.js
@@ -2,16 +2,14 @@ import React, { Component } from "react";
 import { Stage } from "react-pixi-fiber";
 import Bunny from "../Bunny";
 
+const OPTIONS = {
+  backgroundColor: 0x1099bb,
+};
+
 class CanvasPropsExample extends Component {
   render() {
     return (
-      <Stage
-        width={800}
-        height={600}
-        backgroundColor={0x1099bb}
-        className="bordered"
-        style={{ transform: "scale(0.5)" }}
-      >
+      <Stage width={800} height={600} options={OPTIONS} className="bordered" style={{ transform: "scale(0.5)" }}>
         <Bunny x={400} y={300} />
       </Stage>
     );

--- a/examples/src/ClickExample/index.js
+++ b/examples/src/ClickExample/index.js
@@ -6,10 +6,14 @@ import Bunny from "../Bunny";
 // Scale mode for all textures, will retain pixelation
 PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST;
 
+const OPTIONS = {
+  backgroundColor: 0x1099bb,
+};
+
 // http://pixijs.io/examples/#/basics/click.js
 class ClickExample extends Component {
   state = {
-    scale: 1
+    scale: 1,
   };
 
   handleClick = () => {
@@ -18,7 +22,7 @@ class ClickExample extends Component {
 
   render() {
     return (
-      <Stage width={800} height={600} backgroundColor={0x1099bb}>
+      <Stage width={800} height={600} options={OPTIONS}>
         <Bunny
           // Shows hand cursor
           buttonMode

--- a/examples/src/ExampleList/index.js
+++ b/examples/src/ExampleList/index.js
@@ -7,9 +7,9 @@ const propTypes = {
     PropTypes.shape({
       component: PropTypes.func.isRequired,
       name: PropTypes.string.isRequired,
-      slug: PropTypes.string.isRequired
+      slug: PropTypes.string.isRequired,
     })
-  )
+  ),
 };
 
 function ExampleList({ examples }) {

--- a/examples/src/PointsExample/PointsExample.js
+++ b/examples/src/PointsExample/PointsExample.js
@@ -1,0 +1,64 @@
+import React, { Component } from "react";
+import { Stage } from "react-pixi-fiber";
+import * as PIXI from "pixi.js";
+import Bunny from "../Bunny/Bunny";
+
+// Scale mode for all textures, will retain pixelation
+PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST;
+
+const WIDTH = 800;
+const HEIGHT = 600;
+
+class PointsExample extends Component {
+  constructor() {
+    super();
+
+    this.randomPosition = new PIXI.ObservablePoint(
+      this.bunnyHasMoved,
+      this,
+      Math.random() * WIDTH,
+      Math.random() * HEIGHT
+    );
+  }
+
+  bunnyHasMoved = () => {
+    this.forceUpdate(() => {
+      console.log(`Bunny has moved to ${this.randomPosition.x},${this.randomPosition.y}`);
+    });
+  };
+
+  escape = () => {
+    this.randomPosition.set(Math.random() * WIDTH, Math.random() * HEIGHT);
+  };
+
+  render() {
+    return (
+      <Stage width={WIDTH} height={HEIGHT} backgroundColor={0x1099bb}>
+        {/* Position via single value of X as string */}
+        <Bunny position="75" />
+        {/* Position via single value of X as number */}
+        <Bunny position={150} />
+        {/* Position via single value of X in array */}
+        <Bunny position={[225]} />
+        {/* Position via list of X and Y as comma delimited string */}
+        <Bunny position="300,300" />
+        {/* Position via single value of X as string */}
+        <Bunny position={[375, 375]} />
+        {/* Position via list of X and Y in array */}
+        <Bunny position={{ x: 450, y: 450 }} />
+        {/* Position via explicit PIXI.Point */}
+        <Bunny position={new PIXI.Point(525, 525)} />
+        {/* Position via explicit PIXI.ObservablePoint */}
+        <Bunny
+          // Opt-in to interactivity
+          interactive
+          // Pointers normalize touch and mouse
+          pointerover={this.escape}
+          position={this.randomPosition}
+        />
+      </Stage>
+    );
+  }
+}
+
+export default PointsExample;

--- a/examples/src/PointsExample/PointsExample.js
+++ b/examples/src/PointsExample/PointsExample.js
@@ -1,13 +1,16 @@
 import React, { Component } from "react";
 import { Stage } from "react-pixi-fiber";
 import * as PIXI from "pixi.js";
-import Bunny from "../Bunny/Bunny";
+import Bunny from "../Bunny";
 
 // Scale mode for all textures, will retain pixelation
 PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST;
 
 const WIDTH = 800;
 const HEIGHT = 600;
+const OPTIONS = {
+  backgroundColor: 0x1099bb,
+};
 
 class PointsExample extends Component {
   constructor() {
@@ -33,7 +36,7 @@ class PointsExample extends Component {
 
   render() {
     return (
-      <Stage width={WIDTH} height={HEIGHT} backgroundColor={0x1099bb}>
+      <Stage width={WIDTH} height={HEIGHT} options={OPTIONS}>
         {/* Position via single value of X as string */}
         <Bunny position="75" />
         {/* Position via single value of X as number */}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/pixi.js": "^4.4.0",
     "@types/react": "^16.0.0",
     "babel-cli": "^6.26.0",
+    "babel-eslint": "^8.2.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -33,15 +33,14 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.1",
-    "eslint": "^4.8.0",
+    "eslint": "^4.17.0",
     "eslint-config-fbjs": "^2.0.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-babel": "^4.1.0",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-node": "^5.2.0",
-    "eslint-plugin-prettier": "^2.4.0",
+    "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-react": "^7.5.0",
+    "eslint-plugin-react": "^7.6.1",
     "prettier": "^1.9.2"
   },
   "scripts": {

--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -6,10 +6,40 @@ import invariant from "fbjs/lib/invariant";
 import now from "performance-now";
 import * as PIXI from "pixi.js";
 
+// List of props that should be handled in a specific way
 const RESERVED_PROPS = {
-  children: true
+  children: true, // special handling in React
 };
 
+// List of default values for DisplayObject members
+const DEFAULT_PROPS = {
+  alpha: 1,
+  buttonMode: false,
+  cacheAsBitmap: false,
+  cursor: "auto",
+  filterArea: null,
+  filters: null,
+  hitArea: null,
+  interactive: false,
+  // localTransform  // readonly
+  mask: null,
+  // parent  // readonly
+  pivot: 0,
+  position: 0,
+  renderable: true,
+  rotation: 0,
+  scale: 1,
+  skew: 0,
+  transform: null,
+  visible: true,
+  // worldAlpha  // readonly
+  // worldTransform  // readonly
+  // worldVisible  // readonly
+  x: 0,
+  y: 0,
+};
+
+// List of types supported by ReactPixiFiber
 const TYPES = {
   BITMAP_TEXT: "BitmapText",
   CONTAINER: "Container",
@@ -17,7 +47,7 @@ const TYPES = {
   PARTICLE_CONTAINER: "ParticleContainer",
   SPRITE: "Sprite",
   TEXT: "Text",
-  TILING_SPRITE: "TilingSprite"
+  TILING_SPRITE: "TilingSprite",
 };
 
 const UPDATE_SIGNAL = {};
@@ -25,9 +55,20 @@ const UPDATE_SIGNAL = {};
 /* Render Methods */
 
 // TODO consider whitelisting props based on component type
-const applyProps = (instance, props, prevProps) => {
-  Object.assign(instance, filterByKey(props, filterReservedProps));
-};
+function applyProps(instance, props, prevProps) {
+  Object.keys(filterByKey(props, filterReservedProps)).forEach(propName => {
+    const value = props[propName];
+
+    // Set value if defined
+    if (typeof value !== "undefined") {
+      setPixiValue(instance, propName, value);
+    } else if (typeof instance[propName] !== "undefined" && typeof DEFAULT_PROPS[propName] !== "undefined") {
+      // Reset to default value (if it is defined) when display object had prop set and no longer has
+      console.warn(`setting DEFAULT PROP: ${propName} was ${instance[propName]} is ${value} for`, instance);
+      setPixiValue(instance, propName, DEFAULT_PROPS[propName]);
+    }
+  });
+}
 
 function render(pixiElement, stage, callback) {
   let container = stage._reactRootContainer;
@@ -41,14 +82,67 @@ function render(pixiElement, stage, callback) {
   ReactPixiFiber.injectIntoDevTools({
     findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,
     bundleType: 1,
-    version: "0.2.0",
-    rendererPackageName: "react-pixi-fiber"
+    version: "0.2.5",
+    rendererPackageName: "react-pixi-fiber",
   });
+}
+
+/* Point related Methods */
+
+// Converts value to an array of coordinates
+function parsePoint(value) {
+  let arr = [];
+  if (typeof value === "string") {
+    arr = value.split(",");
+  } else if (typeof value === "number") {
+    arr = [value];
+  } else if (Array.isArray(value)) {
+    // shallow copy the array
+    arr = value.slice();
+  } else if (typeof value.x !== "undefined" && typeof value.y !== "undefined") {
+    arr = [value.x, value.y];
+  }
+
+  return arr.map(Number);
+}
+
+function isPointType(value) {
+  return value instanceof PIXI.Point || value instanceof PIXI.ObservablePoint;
+}
+
+// Set props on a DisplayObject by checking the type. If a PIXI.Point or
+// a PIXI.ObservablePoint is having its value set, then either a comma-separated
+// string with in the form of "x,y" or a size 2 array with index 0 being the x
+// coordinate and index 1 being the y coordinate.
+// See: https://github.com/Izzimach/react-pixi/blob/a25196251a13ed9bb116a8576d93e9fceac2a14c/src/ReactPIXI.js#L114
+function setPixiValue(instance, propName, value) {
+  if (isPointType(instance[propName]) && isPointType(value)) {
+    // Just copy the data if a Point type is being assigned to a Point type
+    instance[propName].copy(value);
+  } else if (isPointType(instance[propName])) {
+    // Parse value if a non-Point type is being assigned to a Point type
+    const coordinateData = parsePoint(value);
+
+    invariant(
+      typeof coordinateData !== "undefined" && coordinateData.length > 0 && coordinateData.length < 3,
+      "The property '%s' is a PIXI.Point or PIXI.ObservablePoint and must be set to a comma-separated string of " +
+        "either 1 or 2 coordinates, a 1 or 2 element array containing coordinates, or a PIXI Point/ObservablePoint. " +
+        "If only one coordinate is given then X and Y will be set to the provided value. Received: '%s' of type '%s'.",
+      propName,
+      JSON.stringify(value),
+      typeof value
+    );
+
+    instance[propName].set(coordinateData.shift(), coordinateData.shift());
+  } else {
+    // Just assign the value directly if a non-Point type is being assigned to a non-Point type
+    instance[propName] = value;
+  }
 }
 
 /* Helper Methods */
 
-const filterByKey = (inputObject, filter) => {
+function filterByKey(inputObject, filter) {
   const exportObject = {};
 
   Object.keys(inputObject)
@@ -58,7 +152,7 @@ const filterByKey = (inputObject, filter) => {
     });
 
   return exportObject;
-};
+}
 const filterProps = props => key => props.indexOf(key) === -1;
 const filterReservedProps = filterProps(Object.keys(RESERVED_PROPS));
 
@@ -71,17 +165,14 @@ function appendChild(parentInstance, child) {
   parentInstance.addChild(child);
 }
 
-const removeChild = (parentInstance, child) => {
+function removeChild(parentInstance, child) {
   parentInstance.removeChild(child);
 
   child.destroy();
-};
+}
 
-const insertBefore = (parentInstance, child, beforeChild) => {
-  invariant(
-    child !== beforeChild,
-    "ReactPixiFiber cannot insert node before itself"
-  );
+function insertBefore(parentInstance, child, beforeChild) {
+  invariant(child !== beforeChild, "ReactPixiFiber cannot insert node before itself");
 
   const childExists = parentInstance.children.indexOf(child) !== -1;
   const index = parentInstance.getChildIndex(beforeChild);
@@ -91,18 +182,11 @@ const insertBefore = (parentInstance, child, beforeChild) => {
   } else {
     parentInstance.addChildAt(child, index);
   }
-};
+}
 
-const commitUpdate = (
-  instance,
-  updatePayload,
-  type,
-  oldProps,
-  newProps,
-  internalInstanceHandle
-) => {
+function commitUpdate(instance, updatePayload, type, oldProps, newProps, internalInstanceHandle) {
   applyProps(instance, newProps, oldProps);
-};
+}
 
 const ReactPixiFiber = ReactFiberReconciler({
   appendInitialChild: appendChild,
@@ -112,7 +196,7 @@ const ReactPixiFiber = ReactFiberReconciler({
 
     switch (type) {
       case TYPES.BITMAP_TEXT:
-        instance = new PIXI.BitmapText(props.text, props.style);
+        instance = new PIXI.extras.BitmapText(props.text, props.style);
         break;
       case TYPES.CONTAINER:
         instance = new PIXI.Container();
@@ -135,11 +219,7 @@ const ReactPixiFiber = ReactFiberReconciler({
         instance = new PIXI.Text(props.text, props.style, props.canvas);
         break;
       case TYPES.TILING_SPRITE:
-        instance = new PIXI.extras.TilingSprite(
-          props.texture,
-          props.width,
-          props.height
-        );
+        instance = new PIXI.extras.TilingSprite(props.texture, props.width, props.height);
         break;
       default:
         break;
@@ -152,66 +232,48 @@ const ReactPixiFiber = ReactFiberReconciler({
     return instance;
   },
 
-  createTextInstance(text, rootContainerInstance, internalInstanceHandle) {
-    invariant(
-      false,
-      "ReactPixiFiber does not support text instances. Use Text component instead."
-    );
+  createTextInstance: function(text, rootContainerInstance, internalInstanceHandle) {
+    invariant(false, "ReactPixiFiber does not support text instances. Use Text component instead.");
   },
 
-  finalizeInitialChildren: function(
-    pixiElement,
-    type,
-    props,
-    rootContainerInstance
-  ) {
+  finalizeInitialChildren: function(pixiElement, type, props, rootContainerInstance) {
     return false;
   },
 
-  getChildHostContext(parentHostContext, type) {
+  getChildHostContext: function(parentHostContext, type) {
     return emptyObject;
   },
 
-  getRootHostContext(rootContainerInstance) {
+  getRootHostContext: function(rootContainerInstance) {
     return emptyObject;
   },
 
-  getPublicInstance(inst) {
+  getPublicInstance: function(inst) {
     return inst;
   },
 
   now: now,
 
-  prepareForCommit() {
+  prepareForCommit: function() {
     // Noop
   },
 
-  prepareUpdate: function(
-    pixiElement,
-    type,
-    oldProps,
-    newProps,
-    rootContainerInstance,
-    hostContext
-  ) {
+  prepareUpdate: function(pixiElement, type, oldProps, newProps, rootContainerInstance, hostContext) {
     return UPDATE_SIGNAL;
   },
 
-  resetAfterCommit() {
+  resetAfterCommit: function() {
     // Noop
   },
 
-  resetTextContent(pixiElement) {
+  resetTextContent: function(pixiElement) {
     // Noop
   },
 
   shouldDeprioritizeSubtree: function(type, props) {
-    const isAlphaVisible =
-      typeof props.alpha === "undefined" || props.alpha > 0;
-    const isRenderable =
-      typeof props.renderable === "undefined" || props.renderable === true;
-    const isVisible =
-      typeof props.visible === "undefined" || props.visible === true;
+    const isAlphaVisible = typeof props.alpha === "undefined" || props.alpha > 0;
+    const isRenderable = typeof props.renderable === "undefined" || props.renderable === true;
+    const isVisible = typeof props.visible === "undefined" || props.visible === true;
 
     return !(isAlphaVisible && isRenderable && isVisible);
   },
@@ -232,24 +294,22 @@ const ReactPixiFiber = ReactFiberReconciler({
     removeChild: removeChild,
     removeChildFromContainer: removeChild,
 
-    commitTextUpdate: (textInstance, oldText, newText) => {
+    commitTextUpdate: function(textInstance, oldText, newText) {
       // Noop
     },
 
-    commitMount: (instance, type, newProps) => {
+    commitMount: function(instance, type, newProps) {
       // Noop
     },
 
-    commitUpdate: commitUpdate
-  }
+    commitUpdate: commitUpdate,
+  },
 });
 
 /* React Components */
 
 function validateCanvas(props, propName, componentName) {
-  const isCanvas =
-    props[propName] instanceof Element &&
-    typeof props[propName].getContext === "function";
+  const isCanvas = props[propName] instanceof Element && typeof props[propName].getContext === "function";
   if (!isCanvas) {
     const propType = typeof props[propName];
     return new Error(
@@ -276,21 +336,21 @@ const StagePropTypes = {
     sharedTicker: PropTypes.bool,
     transparent: PropTypes.bool,
     view: validateCanvas,
-    width: PropTypes.number
+    width: PropTypes.number,
   }),
   children: PropTypes.node,
   height: PropTypes.number,
-  width: PropTypes.number
+  width: PropTypes.number,
 };
 const StageChildContextTypes = {
-  app: PropTypes.object
+  app: PropTypes.object,
 };
 const filterStageProps = filterProps(Object.keys(StagePropTypes));
 
 class Stage extends React.Component {
   getChildContext() {
     return {
-      app: this._app
+      app: this._app,
     };
   }
 
@@ -299,7 +359,7 @@ class Stage extends React.Component {
 
     this._app = new PIXI.Application(width, height, {
       view: this._canvas,
-      ...options
+      ...options,
     });
 
     this._mountNode = ReactPixiFiber.createContainer(this._app.stage);
@@ -309,7 +369,7 @@ class Stage extends React.Component {
       findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,
       bundleType: 1,
       version: "0.2.0",
-      rendererPackageName: "react-pixi-fiber"
+      rendererPackageName: "react-pixi-fiber",
     });
   }
 

--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -393,7 +393,7 @@ class Stage extends React.Component {
     const canvasProps = filterByKey(this.props, filterStageProps);
 
     // Do not render anything if view is passed to options
-    if (options.view) {
+    if (typeof options !== "undefined" && options.view) {
       return null;
     } else {
       return <canvas ref={ref => (this._canvas = ref)} {...canvasProps} />;

--- a/src/react-pixi-alias/index.js
+++ b/src/react-pixi-alias/index.js
@@ -15,7 +15,7 @@ const ReactPIXI = {
   Sprite: ReactPixiFiber.Sprite,
   Stage: ReactPixiFiber.Stage,
   Text: ReactPixiFiber.Text,
-  TilingSprite: ReactPixiFiber.TilingSprite
+  TilingSprite: ReactPixiFiber.TilingSprite,
 };
 
 export default ReactPIXI;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,58 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz#2349d7ec04b3a06945ae173280ef8579b63728e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/helper-function-name@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.36.tgz#366e3bc35147721b69009f803907c4d53212e88d"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.36"
+    "@babel/template" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+
+"@babel/helper-get-function-arity@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.36.tgz#f5383bac9a96b274828b10d98900e84ee43e32b8"
+  dependencies:
+    "@babel/types" "7.0.0-beta.36"
+
+"@babel/template@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.36.tgz#02e903de5d68bd7899bce3c5b5447e59529abb00"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
+    lodash "^4.2.0"
+
+"@babel/traverse@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.36.tgz#1dc6f8750e89b6b979de5fe44aa993b1a2192261"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/helper-function-name" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
+    debug "^3.0.1"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.36":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.36.tgz#64f2004353de42adb72f9ebb4665fc35b5499d23"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@types/pixi.js@^4.4.0":
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@types/pixi.js/-/pixi.js-4.7.0.tgz#df14c36b2d1e264668d46f00d0aee691016a7cfe"
@@ -213,6 +265,17 @@ babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-eslint@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.1.tgz#136888f3c109edc65376c23ebf494f36a3e03951"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.36"
+    "@babel/traverse" "7.0.0-beta.36"
+    "@babel/types" "7.0.0-beta.36"
+    babylon "7.0.0-beta.36"
+    eslint-scope "~3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.26.0:
   version "6.26.0"
@@ -675,6 +738,10 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
+babylon@7.0.0-beta.36:
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.36.tgz#3a3683ba6a9a1e02b0aa507c8e63435e39305b9e"
+
 babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
@@ -890,7 +957,7 @@ debug@^2.2.0, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -1067,7 +1134,7 @@ eslint-plugin-react@^7.6.1:
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.0"
 
-eslint-scope@^3.7.1:
+eslint-scope@^3.7.1, eslint-scope@~3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
@@ -1380,7 +1447,7 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.0.1:
+globals@^11.0.1, globals@^11.1.0:
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
 
@@ -1512,7 +1579,7 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -1784,7 +1851,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -2545,6 +2612,10 @@ tmp@^0.0.33:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@~2.3.0:
   version "2.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,9 +24,9 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.2.1:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+acorn@^5.4.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
@@ -64,7 +64,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -706,8 +706,8 @@ boom@2.x.x:
     hoek "2.x.x"
 
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -760,12 +760,12 @@ chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
   dependencies:
-    ansi-styles "^3.1.0"
+    ansi-styles "^3.2.0"
     escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
+    supports-color "^5.2.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -948,9 +948,9 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0, doctrine@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
+doctrine@^2.0.2, doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
 
@@ -1047,18 +1047,9 @@ eslint-plugin-import@^2.8.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-node@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz#80df3253c4d7901045ec87fa660a284e32bdca29"
-  dependencies:
-    ignore "^3.3.6"
-    minimatch "^3.0.4"
-    resolve "^1.3.3"
-    semver "5.3.0"
-
-eslint-plugin-prettier@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz#85cab0775c6d5e3344ef01e78d960f166fb93aae"
+eslint-plugin-prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
   dependencies:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
@@ -1067,13 +1058,13 @@ eslint-plugin-promise@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
 
-eslint-plugin-react@^7.5.0:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz#52e56e8d80c810de158859ef07b880d2f56ee30b"
+eslint-plugin-react@^7.6.1:
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz#5d0e908be599f0c02fbf4eef0c7ed6f29dff7633"
   dependencies:
-    doctrine "^2.0.0"
+    doctrine "^2.0.2"
     has "^1.0.1"
-    jsx-ast-utils "^2.0.0"
+    jsx-ast-utils "^2.0.1"
     prop-types "^15.6.0"
 
 eslint-scope@^3.7.1:
@@ -1087,9 +1078,9 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.8.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.14.0.tgz#96609768d1dd23304faba2d94b7fefe5a5447a82"
+eslint@^4.17.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.17.0.tgz#dc24bb51ede48df629be7031c71d9dc0ee4f3ddf"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -1097,7 +1088,7 @@ eslint@^4.8.0:
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
     debug "^3.1.0"
-    doctrine "^2.0.2"
+    doctrine "^2.1.0"
     eslint-scope "^3.7.1"
     eslint-visitor-keys "^1.0.0"
     espree "^3.5.2"
@@ -1130,10 +1121,10 @@ eslint@^4.8.0:
     text-table "~0.2.0"
 
 espree@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
   dependencies:
-    acorn "^5.2.1"
+    acorn "^5.4.0"
     acorn-jsx "^3.0.0"
 
 esprima@^4.0.0:
@@ -1390,8 +1381,8 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     path-is-absolute "^1.0.0"
 
 globals@^11.0.1:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -1429,9 +1420,9 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1479,7 +1470,7 @@ iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ignore@^3.3.3, ignore@^3.3.6:
+ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -1642,8 +1633,8 @@ is-regex@^1.0.4:
     has "^1.0.1"
 
 is-resolvable@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.1.tgz#acca1cd36dbe44b974b924321555a70ba03b1cf4"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-stream@^1.0.1:
   version "1.1.0"
@@ -1748,7 +1739,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.0.0:
+jsx-ast-utils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
@@ -1794,8 +1785,8 @@ lodash.cond@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
 lodash@^4.17.4, lodash@^4.3.0:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
@@ -1839,8 +1830,8 @@ mime-types@^2.1.12, mime-types@~2.1.7:
     mime-db "~1.30.0"
 
 mimic-fn@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
@@ -2112,6 +2103,10 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
@@ -2182,7 +2177,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -2190,6 +2185,18 @@ readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.2.2:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
@@ -2303,7 +2310,7 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.2.0, resolve@^1.3.3:
+resolve@^1.2.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
@@ -2342,13 +2349,13 @@ safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0:
+"semver@2 || 3 || 4 || 5":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
-semver@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+semver@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -2483,11 +2490,11 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+supports-color@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
   dependencies:
-    has-flag "^2.0.0"
+    has-flag "^3.0.0"
 
 table@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR restores backwards `react-pixi` compatibility with regards to:
1. Assigning strings, numbers, arrays or `Point`/`ObservablePoint` [PIXI.Point](PIXIjs.download/release/docs/PIXI.Point.html)-like props (ported from `react-pixi` in #20).
2. Dealing with `undefined` values for some [PIXI.DisplayObject](http://pixijs.download/release/docs/PIXI.DisplayObject.html) members.