### PR TITLE
Fix tree updates

### DIFF
--- a/src/props.js
+++ b/src/props.js
@@ -1,6 +1,8 @@
+export const CHILDREN = "children";
+
 // List of props that should be handled in a specific way
 export const RESERVED_PROPS = {
-  children: true, // special handling in React
+  [CHILDREN]: true, // special handling in React
 };
 
 // List of default values for DisplayObject members

--- a/test/props.test.js
+++ b/test/props.test.js
@@ -1,9 +1,14 @@
-import { DEFAULT_PROPS, RESERVED_PROPS } from "../src/props";
+import { CHILDREN, DEFAULT_PROPS, RESERVED_PROPS } from "../src/props";
 
 describe("props", () => {
+  describe("CHILDREN", () => {
+    it("equals `children`", () => {
+      expect(CHILDREN).toEqual("children");
+    });
+  });
   describe("RESERVED_PROPS", () => {
     it("contain `children`", () => {
-      expect(RESERVED_PROPS).toHaveProperty("children");
+      expect(RESERVED_PROPS).toHaveProperty(CHILDREN);
     });
   });
   describe("DEFAULT_PROPS", () => {


### PR DESCRIPTION
`prepareUpdate` now returns props diff that can be `null` to block unnecessary updates from happening