### PR TITLE
support typescript 2.9.x with Create-React-App

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,18 +4,11 @@ import * as PIXI from 'pixi.js';
 declare module 'react-pixi-fiber' {
 
   /**
-   * The set of object keys in T not in U.
-   *
-   * Attribution: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766:
-   */
-  export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-
-  /**
    * An object with keys in T not in U.
    *
-   * Attribution: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766:
+   * Attribution: https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
    */
-  export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+  export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
   /** The shape of an object that has an optional `children` property of any type. */
   interface ObjectWithChildren { children?: any; }


### PR DESCRIPTION
This is a typescript update addressing a breaking change by typescript here: https://blogs.msdn.microsoft.com/typescript/2018/05/31/announcing-typescript-2-9/#breaking-changes

This removes the custom implementation of `Diff` for the native `Exclude`.

The issue affects `create-react-app` users, and likely others.  

Details: https://github.com/michalochman/react-pixi-fiber/issues/58
Repo to reproduce problem: https://github.com/seethroughtrees/test-pixi-fiber

Would appreciate a typescript reviewer to verify no issues I'm not thinking of.  but appears to work as expected.


