### PR TITLE
Fix width and height behavior for Stage options

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -67,7 +67,9 @@ class Stage extends React.Component {
   componentDidMount() {
     const { children, height, options, width } = this.props;
 
-    this._app = new PIXI.Application(width, height, {
+    this._app = new PIXI.Application({
+      height,
+      width,
       view: this._canvas,
       ...options,
     });
@@ -92,15 +94,20 @@ class Stage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { children, height, width } = this.props;
+    const { children, height, options, width } = this.props;
+    const { options: prevOptions } = prevProps;
 
     // Apply root Container props
     const stageProps = getDisplayObjectProps(this.props);
     applyProps(this._app.stage, {}, stageProps);
 
     // Root container has been resized - resize renderer
-    if (height !== prevProps.height || width !== prevProps.width) {
-      this._app.renderer.resize(width, height);
+    const currentHeight = (options && options.height) || height;
+    const currentWidth = (options && options.width) || width;
+    const prevHeight = (prevOptions && prevOptions.height) || prevProps.height;
+    const prevWidth = (prevOptions && prevOptions.width) || prevProps.width;
+    if (currentHeight !== prevHeight || currentWidth !== prevWidth) {
+      this._app.renderer.resize(currentWidth, currentHeight);
     }
 
     ReactPixiFiber.updateContainer(children, this._mountNode, this);

--- a/test/Stage.test.js
+++ b/test/Stage.test.js
@@ -80,6 +80,22 @@ describe("Stage", () => {
     });
   });
 
+  it("creates PIXI.Application instance with 'height' and 'width' in options", () => {
+    const options = {
+      backgroundColor: 0xff00ff,
+      height: 300,
+      sharedTicker: true,
+      width: 400,
+    };
+
+    const element = renderer.create(<Stage options={options} />);
+    const instance = element.getInstance();
+    const app = instance._app;
+
+    expect(app instanceof PIXI.Application).toBeTruthy();
+    expect(app._options).toMatchObject(options);
+  });
+
   it("creates root Container", () => {
     const element = renderer.create(<Stage height={300} width={400} scale={2} position="40,20" />);
     const instance = element.getInstance();


### PR DESCRIPTION
Make "width" and "height" able to be passed into "options" prop in `<Stage />`.

### Reproduce

```jsx
<Stage options={{
  width: 800,
  height: 600,
}}/>
```

### What is expected?

Render a 800x600 canvas element onto dom.

### What is actually happending?

Render a default canvas element without width and height attributes. It's not the same behavior as [README](https://github.com/michalochman/react-pixi-fiber#stage-) said.