### PR TITLE
fix memory leak

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -108,6 +108,7 @@ class Stage extends React.Component {
 
   componentWillUnmount() {
     ReactPixiFiber.updateContainer(null, this._mountNode, this);
+    this._app.destroy();
   }
 
   render() {


### PR DESCRIPTION
Hello,

This fix improves a memory leak that occurs when unmounting the `Stage` from the render tree.

-----

**Before:**
![before](https://user-images.githubusercontent.com/6138982/41191644-b169a94e-6c2d-11e8-8c48-3e8ae2cfad40.png)
![before2](https://user-images.githubusercontent.com/6138982/41191645-b3143f70-6c2d-11e8-8964-ec114a0839a7.png)

-----

**After:**
![after](https://user-images.githubusercontent.com/6138982/41191646-b78d0a82-6c2d-11e8-9bb1-dcb070588150.png)

-----

Thank you for your great work!