### PR TITLE
Remove namespace from Typescript definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
 
       # run tests
       - run: yarn test --coverage --ci --silent
+      - run: yarn test:ts
 
       # upload coverage report
       - run: yarn codecov

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,13 +144,11 @@ declare module 'react-pixi-fiber' {
   /**
    * Create a custom component.
    */
-  namespace CustomPIXIComponentNamespace {
-    export function CustomPIXIComponent<T, U extends PIXI.DisplayObject>(
-      behavior: Behavior<T, U>,
-      /**
-       * The name of this custom component.
-       */
-      type: string
-    ): React.ReactType<T>;
-  }
+  export function CustomPIXIComponent<T, U extends PIXI.DisplayObject>(
+    behavior: Behavior<T, U>,
+    /**
+     * The name of this custom component.
+     */
+    type: string
+  ): React.ReactType<T>;
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/pixi.js": "^4.7.3",
-    "@types/react": "^16.3.14",
+    "@types/react": "^16.0.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-jest": "^22.4.3",
@@ -61,7 +61,8 @@
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^3.0.0",
-    "rollup-plugin-visualizer": "^0.6.0"
+    "rollup-plugin-visualizer": "^0.6.0",
+    "typescript": "^2.9.2"
   },
   "scripts": {
     "build": "npm run build:prod && npm run build:dev",
@@ -74,7 +75,8 @@
     "eslint": "eslint src",
     "eslint-check": "eslint --print-config .eslintrc.json | eslint-config-prettier-check",
     "prepublish": "npm run build",
-    "test": "jest"
+    "test": "jest",
+    "test:ts": "tsc -p tsconfig.json"
   },
   "jest": {
     "coverageDirectory": "coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "compilerOptions": {
     "lib": ["es2015", "dom"],
+    "noEmit": true,
     "strict": true,
     "jsx": "react",
     "baseUrl": "./",
     "paths": {
       "react-pixi-fiber": ["index.d.ts"]
     }
-  }
+  },
+  "files": [
+    "test/typescript/index.tsx"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,9 +104,9 @@
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@types/pixi.js/-/pixi.js-4.7.3.tgz#53e9b3df583cd985c773f42123abcfc345a04c3d"
 
-"@types/react@^16.3.14":
-  version "16.3.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.14.tgz#f90ac6834de172e13ecca430dcb6814744225d36"
+"@types/react@^16.0.0":
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.1.tgz#c53bbfb4a78933db587da085ac60dbf5fcf73f8f"
   dependencies:
     csstype "^2.2.0"
 
@@ -1251,8 +1251,8 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
     cssom "0.3.x"
 
 csstype@^2.2.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.0.tgz#53e1c242f422d5d976b81f42707bd9b8934492ee"
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.5.tgz#4125484a3d42189a863943f23b9e4b80fedfa106"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -4076,6 +4076,10 @@ type-check@~0.3.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
I'm not sure if it's a bug or it's just that I don't understand how the namespace works, but currently in order to do
```js
import { CustomPIXIComponent } from 'react-pixi-fiber';
```
instead Typescript requires me to write
```js
import { CustomPIXIComponentNamespace } from 'react-pixi-fiber';
CustomPIXIComponentNamespace.CustomPIXIComponent
```
and then the compiled JS code fails because
```Uncaught TypeError: Cannot read property 'CustomPIXIComponent' of undefined```

I think this namespace should be removed.