### PR TITLE
Support both new and legacy Context APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added support for New Context API
+
+### Fixed
+- Fixed React 16.5.0 compatibility ([#71])
+
 
 ## [0.4.9] - 2018-07-09
 
@@ -191,6 +197,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.2.0]: https://github.com/michalochman/react-pixi-fiber/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/michalochman/react-pixi-fiber/compare/v0.1.0...v0.1.1
 
+[#71]: https://github.com/michalochman/react-pixi-fiber/issues/71
 [#67]: https://github.com/michalochman/react-pixi-fiber/pull/67
 [#65]: https://github.com/michalochman/react-pixi-fiber/pull/65
 [#64]: https://github.com/michalochman/react-pixi-fiber/pull/64

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ These won't actually replace the property but they will be applied using the ori
   * `ticker` – Ticker for doing render updates,
   * `view` – reference to the renderer's canvas element. 
 
-#### Using `withApp` Higher-Order Component
+#### Using `withApp` Higher-Order Component (with React <16.3.0 and React >=16.3.0)
 
 To get `app` prop in your component you may wrap it with `withApp` higher-order component:
 

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -1,4 +1,4 @@
-import json from "rollup-plugin-json";
+const json = require("rollup-plugin-json");
 const babel = require("rollup-plugin-babel");
 const commonjs = require("rollup-plugin-commonjs");
 const globals = require("rollup-plugin-node-globals");
@@ -43,6 +43,7 @@ const getPlugins = () => [
       "node_modules/react/**",
       "node_modules/react-dom/**",
       "node_modules/react-reconciler/**",
+      "node_modules/schedule/**",
     ],
   }),
   globals(),

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "dependencies": {
     "animated": "^0.2.2",
+    "pixi.js": "4.8.2",
     "pixi-layers": "^0.1.9",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-pixi-fiber": "0.4.9",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.0.17",

--- a/examples/src/BunnyExample/RotatingBunny.js
+++ b/examples/src/BunnyExample/RotatingBunny.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { withApp } from "react-pixi-fiber";
 import Bunny from "../Bunny";
 
 // http://pixijs.io/examples/#/basics/basic.js
@@ -9,11 +10,11 @@ class RotatingBunny extends Component {
   };
 
   componentDidMount() {
-    this.context.app.ticker.add(this.animate);
+    this.props.app.ticker.add(this.animate);
   }
 
   componentWillUnmount() {
-    this.context.app.ticker.remove(this.animate);
+    this.props.app.ticker.remove(this.animate);
   }
 
   animate = delta => {
@@ -30,8 +31,8 @@ class RotatingBunny extends Component {
     return <Bunny {...this.props} rotation={this.state.rotation} />;
   }
 }
-RotatingBunny.contextTypes = {
-  app: PropTypes.object,
+RotatingBunny.propTypes = {
+  app: PropTypes.object.isRequired,
 };
 
-export default RotatingBunny;
+export default withApp(RotatingBunny);

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -989,6 +989,10 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
+bit-twiddle@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bit-twiddle/-/bit-twiddle-1.0.2.tgz#0c6c1fabe2b23d17173d9a61b7b7093eb9e1769e"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -1973,6 +1977,10 @@ duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
+earcut@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.3.tgz#ca579545f351941af7c3d0df49c9f7d34af99b0c"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -2324,6 +2332,10 @@ eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
 
+eventemitter3@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -2487,7 +2499,19 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.16:
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
+fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3422,6 +3446,10 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
+ismobilejs@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/ismobilejs/-/ismobilejs-0.4.1.tgz#1a5f126c70fed39c93da380fa62cbae5723e7dc2"
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -4146,6 +4174,10 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
+mini-signals@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mini-signals/-/mini-signals-1.2.0.tgz#45b08013c5fae51a24aa1a935cd317c9ed721d74"
+
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -4555,6 +4587,10 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
+parse-uri@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-uri/-/parse-uri-1.0.0.tgz#2872dcc22f1a797acde1583d8a0ac29552ddac20"
+
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
@@ -4653,11 +4689,28 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pixi-gl-core@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/pixi-gl-core/-/pixi-gl-core-1.1.4.tgz#8b4b5c433b31e419bc379dc565ce1b835a91b372"
+
 pixi-layers@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/pixi-layers/-/pixi-layers-0.1.9.tgz#6ce9cf80ab2916620dd3dbaec7b71153c533a466"
   dependencies:
     "@types/pixi.js" "^4.7.1"
+
+pixi.js@4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/pixi.js/-/pixi.js-4.8.2.tgz#c9e6f5f3b6780d2236705a7539e4e5ca3d74151f"
+  dependencies:
+    bit-twiddle "^1.0.2"
+    earcut "^2.1.3"
+    eventemitter3 "^2.0.0"
+    ismobilejs "^0.4.0"
+    object-assign "^4.0.1"
+    pixi-gl-core "^1.1.4"
+    remove-array-items "^1.0.0"
+    resource-loader "^2.1.1"
 
 pkg-dir@^1.0.0:
   version "1.0.0"
@@ -5025,11 +5078,18 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
     fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+prop-types@^15.6.0, prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -5172,14 +5232,14 @@ react-dev-utils@^4.2.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@^16.0.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.0.tgz#57704e5718669374b182a17ea79a6d24922cb27d"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
 react-error-overlay@^3.0.0:
   version "3.0.0"
@@ -5268,14 +5328,14 @@ react-scripts@1.0.17:
   optionalDependencies:
     fsevents "1.1.2"
 
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@^16.0.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.5.0.tgz#f2c1e754bf9751a549d9c6d9aca41905beb56575"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -5436,6 +5496,10 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remove-array-items@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remove-array-items/-/remove-array-items-1.0.0.tgz#07bf42cb332f4cf6e85ead83b5e4e896d2326b21"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -5576,6 +5640,13 @@ resolve@^1.2.0, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
+resource-loader@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/resource-loader/-/resource-loader-2.1.1.tgz#f03ec08dd26aae0b0dd2a24a6d312aec2b5a004d"
+  dependencies:
+    mini-signals "^1.1.1"
+    parse-uri "^1.0.0"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -5637,6 +5708,12 @@ sane@~1.6.0:
 sax@^1.2.1, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+schedule@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.3.0.tgz#1be2ab2fc2e768536269ce7326efb478d6c045e8"
+  dependencies:
+    object-assign "^4.1.1"
 
 schema-utils@^0.3.0:
   version "0.3.0"
@@ -6215,6 +6292,10 @@ type-is@~1.6.15:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+ua-parser-js@^0.7.18:
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6737,14 +6737,25 @@
       }
     },
     "react-reconciler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.12.0.tgz",
-      "integrity": "sha512-BBaE+asD1HdzS35GLhvOEUGFwFKBNN/Jj9b+VlCt9JjF+jDnmIij4SbulNpqccYxPE/Eeup3/ciouo9YmhSgbg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.13.0.tgz",
+      "integrity": "sha512-7e/EEUgYTYy29p2fgcEhNm1I159IKs5Kk+4QW4Y5AwyD8Y4GZ8M03ZhMhRz8gifG8XFks2vbdpRIT5QGfRPYHw==",
       "requires": {
-        "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.2",
+        "schedule": "0.3.0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "react-test-renderer": {
@@ -7688,6 +7699,14 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "schedule": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.3.0.tgz",
+      "integrity": "sha512-20+1KVo517sR7Nt+bYBN8a+bEJDKLPEx7Ohtts1kX05E4/HY53YUNuhfkVNItmWAnBYHcpG9vsd2/CJxG+aPCQ==",
+      "requires": {
+        "object-assign": "4.1.1"
+      }
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "fbjs": "^0.8.0",
     "performance-now": "^2.1.0",
-    "react-reconciler": "^0.12.0"
+    "react-reconciler": "^0.13.0"
   },
   "peerDependencies": {
     "pixi.js": "^4.4.0",

--- a/src/AppProvider.js
+++ b/src/AppProvider.js
@@ -1,0 +1,77 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const propTypes = {
+  app: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
+};
+const childContextTypes = {
+  app: PropTypes.object,
+};
+
+let AppContext = null;
+
+function createAppProvider() {
+  if (typeof React.createContext === "function") {
+    // New Context API
+    if (AppContext === null) {
+      AppContext = React.createContext(null);
+    }
+
+    class AppProvider extends React.Component {
+      render() {
+        const { app, children } = this.props;
+        return <AppContext.Provider value={app}>{children}</AppContext.Provider>;
+      }
+    }
+
+    AppProvider.propTypes = propTypes;
+
+    const withApp = WrappedComponent => {
+      class WithApp extends React.Component {
+        render() {
+          return <AppContext.Consumer>{app => <WrappedComponent {...this.props} app={app} />}</AppContext.Consumer>;
+        }
+      }
+      WithApp.displayName = `withApp(${WrappedComponent})`;
+
+      return WithApp;
+    };
+
+    return { AppProvider, withApp };
+  } else {
+    // Legacy Context API
+    class AppProvider extends React.Component {
+      getChildContext() {
+        return {
+          app: this.props.app,
+        };
+      }
+
+      render() {
+        return this.props.children;
+      }
+    }
+
+    AppProvider.propTypes = propTypes;
+    AppProvider.childContextTypes = childContextTypes;
+
+    const withApp = WrappedComponent => {
+      class WithApp extends React.Component {
+        render() {
+          return <WrappedComponent {...this.props} app={this.context.app} />;
+        }
+      }
+      WithApp.displayName = `withApp(${WrappedComponent})`;
+      WithApp.contextTypes = childContextTypes;
+
+      return WithApp;
+    };
+
+    return { AppProvider, withApp };
+  }
+}
+
+const { AppProvider, withApp } = createAppProvider();
+
+export { AppContext, AppProvider, withApp };

--- a/src/AppProvider.js
+++ b/src/AppProvider.js
@@ -28,10 +28,8 @@ function createAppProvider() {
     AppProvider.propTypes = propTypes;
 
     const withApp = WrappedComponent => {
-      class WithApp extends React.Component {
-        render() {
-          return <AppContext.Consumer>{app => <WrappedComponent {...this.props} app={app} />}</AppContext.Consumer>;
-        }
+      function WithApp(props) {
+        return <AppContext.Consumer>{app => <WrappedComponent {...props} app={app} />}</AppContext.Consumer>;
       }
       WithApp.displayName = `withApp(${WrappedComponent})`;
 
@@ -57,10 +55,8 @@ function createAppProvider() {
     AppProvider.childContextTypes = childContextTypes;
 
     const withApp = WrappedComponent => {
-      class WithApp extends React.Component {
-        render() {
-          return <WrappedComponent {...this.props} app={this.context.app} />;
-        }
+      function WithApp(props, context) {
+        return <WrappedComponent {...props} app={context.app} />;
       }
       WithApp.displayName = `withApp(${WrappedComponent})`;
       WithApp.contextTypes = childContextTypes;

--- a/src/AppProvider.js
+++ b/src/AppProvider.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 const propTypes = {
   app: PropTypes.object.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 const childContextTypes = {
   app: PropTypes.object,

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -1,10 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import * as PIXI from "pixi.js";
-import pkg from "../package.json";
 import { AppProvider } from "./AppProvider";
 import { DEFAULT_PROPS } from "./props";
-import ReactPixiFiber, { applyProps } from "./ReactPixiFiber";
+import { applyProps } from "./ReactPixiFiber";
 import { render, unmount } from "./render";
 import { filterByKey, including } from "./utils";
 

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -2,8 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import * as PIXI from "pixi.js";
 import pkg from "../package.json";
+import { AppProvider } from "./AppProvider";
 import { DEFAULT_PROPS } from "./props";
 import ReactPixiFiber, { applyProps } from "./ReactPixiFiber";
+import { render, unmount } from "./render";
 import { filterByKey, including } from "./utils";
 
 export function validateCanvas(props, propName, componentName) {
@@ -46,9 +48,6 @@ const propTypes = {
   height: PropTypes.number,
   width: PropTypes.number,
 };
-const childContextTypes = {
-  app: PropTypes.object,
-};
 
 export const includingDisplayObjectProps = including(Object.keys(DEFAULT_PROPS));
 export const includingStageProps = including(Object.keys(propTypes));
@@ -58,12 +57,6 @@ export const getCanvasProps = props => filterByKey(props, includingCanvasProps);
 export const getDisplayObjectProps = props => filterByKey(props, includingDisplayObjectProps);
 
 class Stage extends React.Component {
-  getChildContext() {
-    return {
-      app: this._app,
-    };
-  }
-
   componentDidMount() {
     const { children, height, options, width } = this.props;
 
@@ -78,19 +71,7 @@ class Stage extends React.Component {
     const stageProps = getDisplayObjectProps(this.props);
     applyProps(this._app.stage, {}, stageProps);
 
-    // Perhaps this should use the standalone render method somehow, the only differences now are:
-    // - parentContainer
-    // - callback
-    // - return value
-    this._mountNode = ReactPixiFiber.createContainer(this._app.stage);
-    ReactPixiFiber.updateContainer(children, this._mountNode, this);
-
-    ReactPixiFiber.injectIntoDevTools({
-      findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,
-      bundleType: __DEV__ ? 1 : 0,
-      version: pkg.version,
-      rendererPackageName: pkg.name,
-    });
+    render(<AppProvider app={this._app}>{children}</AppProvider>, this._app.stage);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -110,11 +91,11 @@ class Stage extends React.Component {
       this._app.renderer.resize(currentWidth, currentHeight);
     }
 
-    ReactPixiFiber.updateContainer(children, this._mountNode, this);
+    render(<AppProvider app={this._app}>{children}</AppProvider>, this._app.stage);
   }
 
   componentWillUnmount() {
-    ReactPixiFiber.updateContainer(null, this._mountNode, this);
+    unmount(this._app.stage);
     this._app.destroy();
   }
 
@@ -132,6 +113,5 @@ class Stage extends React.Component {
 }
 
 Stage.propTypes = propTypes;
-Stage.childContextTypes = childContextTypes;
 
 export default Stage;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 import CustomPIXIComponent from "./CustomPIXIComponent";
-import { AppContext, withApp } from "./AppProvider";
+import { AppContext, AppProvider, withApp } from "./AppProvider";
 import Stage from "./Stage";
 import { TYPES } from "./types";
 import { render } from "./render";
 
 /* Public API */
 
-export { AppContext, CustomPIXIComponent, Stage, render, withApp };
+export { AppContext, AppProvider, CustomPIXIComponent, Stage, render, withApp };
 
 export const BitmapText = TYPES.BITMAP_TEXT;
 export const Container = TYPES.CONTAINER;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import CustomPIXIComponent from "./CustomPIXIComponent";
+import { AppContext, withApp } from "./AppProvider";
 import Stage from "./Stage";
 import { TYPES } from "./types";
-import render from "./render";
+import { render } from "./render";
 
 /* Public API */
 
-export { CustomPIXIComponent, Stage, render };
+export { AppContext, CustomPIXIComponent, Stage, render, withApp };
 
 export const BitmapText = TYPES.BITMAP_TEXT;
 export const Container = TYPES.CONTAINER;

--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,5 @@
 import pkg from "../package.json";
+import invariant from "fbjs/lib/invariant";
 import { ReactPixiFiberAsPrimaryRenderer as ReactPixiFiber } from "../src/ReactPixiFiber";
 
 export const roots = new Map();
@@ -7,7 +8,7 @@ export const roots = new Map();
  * element should be any instance of PIXI DisplayObject
  * containerTag should be an instance of PIXI root Container (i.e. the Stage)
  */
-function render(element, containerTag, callback) {
+export function render(element, containerTag, callback) {
   let root = roots.get(containerTag);
   if (!root) {
     root = ReactPixiFiber.createContainer(containerTag);
@@ -26,4 +27,10 @@ function render(element, containerTag, callback) {
   return ReactPixiFiber.getPublicRootInstance(root);
 }
 
-export default render;
+export function unmount(containerTag) {
+  const root = roots.get(containerTag);
+
+  invariant(root, "ReactPixiFiber did not render into container provided");
+
+  ReactPixiFiber.updateContainer(null, root);
+}

--- a/test/AppProvider.test.js
+++ b/test/AppProvider.test.js
@@ -1,0 +1,110 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
+import renderer from "react-test-renderer";
+import { AppContext, AppProvider, Container, Stage, withApp } from "../src";
+import { render } from "../src/render";
+import * as PIXI from "pixi.js";
+
+if (typeof React.createContext === "function") {
+  // New Context API
+  describe("AppProvider using New Context API (React >=16.3.0)", () => {
+    it("exports AppContext with Provider and Consumer", () => {
+      expect(AppContext.Provider).not.toEqual(null);
+      expect(AppContext.Consumer).not.toEqual(null);
+    });
+
+    it("passess app prop to wrapped component", () => {
+      const app = new PIXI.Application();
+      const TestComponent = jest.fn(() => null);
+
+      render(
+        <AppContext.Provider value={app}>
+          <AppContext.Consumer>{app => <TestComponent app={app} foo="bar" />}</AppContext.Consumer>
+        </AppContext.Provider>,
+        app.stage
+      );
+
+      expect(TestComponent).toHaveBeenCalledWith({ app, foo: "bar" }, {});
+    });
+  });
+} else {
+  // Legacy Context API
+  describe("AppProvider using Legacy Context API (React <16.3.0)", () => {
+    it("exports null AppContext", () => {
+      expect(AppContext).toEqual(null);
+    });
+
+    it("passess app context to component rendered inside AppProvider", () => {
+      const app = new PIXI.Application();
+      const TestComponent = jest.fn(() => null);
+      TestComponent.contextTypes = {
+        app: PropTypes.object,
+      };
+
+      render(
+        <AppProvider app={app}>
+          <Container>
+            <TestComponent foo="bar" />
+          </Container>
+        </AppProvider>,
+        app.stage
+      );
+
+      expect(TestComponent).toHaveBeenCalledWith({ foo: "bar" }, { app });
+    });
+
+    it("passess app context to component rendered inside Stage", () => {
+      const TestComponent = jest.fn(() => null);
+      TestComponent.contextTypes = {
+        app: PropTypes.object,
+      };
+
+      let stage;
+      ReactDOM.render(
+        <Stage ref={c => (stage = c)}>
+          <Container>
+            <TestComponent foo="bar" />
+          </Container>
+        </Stage>,
+        document.createElement("div")
+      );
+
+      expect(TestComponent).toHaveBeenCalledWith({ foo: "bar" }, { app: stage._app });
+    });
+  });
+}
+
+describe("withApp", () => {
+  it("passess app prop to component rendered inside AppProvider", () => {
+    const app = new PIXI.Application();
+    const TestComponent = jest.fn(() => null);
+    const TestComponentWithApp = withApp(TestComponent);
+
+    render(
+      <AppProvider app={app}>
+        <Container>
+          <TestComponentWithApp foo="bar" />
+        </Container>
+      </AppProvider>,
+      app.stage
+    );
+
+    expect(TestComponent).toHaveBeenCalledWith({ app, foo: "bar" }, {});
+  });
+
+  it("passess app prop to component rendered inside Stage", () => {
+    const TestComponent = jest.fn(() => null);
+    const TestComponentWithApp = withApp(TestComponent);
+
+    let stage;
+    ReactDOM.render(
+      <Stage ref={c => (stage = c)}>
+        <TestComponentWithApp foo="bar" />
+      </Stage>,
+      document.createElement("div")
+    );
+
+    expect(TestComponent).toHaveBeenCalledWith({ app: stage._app, foo: "bar" }, {});
+  });
+});

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import pkg from "../package.json";
 import { Container, Text } from "../src/index";
 import { ReactPixiFiberAsPrimaryRenderer as ReactPixiFiber } from "../src/ReactPixiFiber";
-import render, { roots } from "../src/render";
+import { render, roots, unmount } from "../src/render";
 
 jest.mock("../src/ReactPixiFiber", () => {
   const actual = require.requireActual("../src/ReactPixiFiber");
@@ -63,5 +63,28 @@ describe("render", () => {
     render(element, root, callback);
 
     expect(ReactPixiFiber.createContainer).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("unmount", () => {
+  beforeEach(() => {
+    roots.clear();
+    jest.resetAllMocks();
+  });
+
+  const app = new PIXI.Application();
+  const root = app.stage;
+
+  it("calls ReactPixiFiber.updateContainer if it was mounted", () => {
+    roots.set(root, app.stage);
+    unmount(root);
+
+    expect(ReactPixiFiber.updateContainer).toHaveBeenCalledTimes(1);
+    expect(ReactPixiFiber.updateContainer).toHaveBeenCalledWith(null, roots.get(root));
+  });
+
+  it("does not update root if it is not present", () => {
+    expect(() => unmount(root)).toThrow("ReactPixiFiber did not render into container provided");
+    expect(ReactPixiFiber.updateContainer).toHaveBeenCalledTimes(0);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,8 +1678,8 @@ fb-watchman@^2.0.0:
     bser "^2.0.0"
 
 fbjs@^0.8.0, fbjs@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -1687,7 +1687,7 @@ fbjs@^0.8.0, fbjs@^0.8.16:
     object-assign "^4.1.0"
     promise "^7.1.1"
     setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
+    ua-parser-js "^0.7.18"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -2012,9 +2012,15 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
+iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+iconv-lite@~0.4.13:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ignore@^3.3.3:
   version "3.3.7"
@@ -2580,6 +2586,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
@@ -2755,10 +2765,10 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
-    js-tokens "^3.0.0"
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -3242,11 +3252,10 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+prop-types@^15.6.0, prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -3287,22 +3296,22 @@ rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-dom@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.0.tgz#57704e5718669374b182a17ea79a6d24922cb27d"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
-react-reconciler@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.12.0.tgz#dd3ecd98f64a2d8449298dadab041910cafd2849"
+react-reconciler@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.13.0.tgz#89a5ff1403d03fee2b8760d515b133ff3d87a044"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
 react-test-renderer@^16.0.0:
   version "16.2.0"
@@ -3313,13 +3322,13 @@ react-test-renderer@^16.0.0:
     prop-types "^15.6.0"
 
 react@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.5.0.tgz#f2c1e754bf9751a549d9c6d9aca41905beb56575"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.3.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3727,6 +3736,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
 sane@^2.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/sane/-/sane-2.4.1.tgz#29f991208cf28636720efdc584293e7fd66663a5"
@@ -3744,6 +3757,12 @@ sane@^2.0.0:
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+schedule@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.3.0.tgz#1be2ab2fc2e768536269ce7326efb478d6c045e8"
+  dependencies:
+    object-assign "^4.1.1"
 
 "semver@2 || 3 || 4 || 5":
   version "5.4.1"
@@ -4081,9 +4100,9 @@ typescript@^2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
-ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+ua-parser-js@^0.7.18:
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 uglify-es@^3.3.7:
   version "3.3.9"
@@ -4196,8 +4215,8 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
     iconv-lite "0.4.19"
 
 whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
 
 whatwg-url@^6.4.0:
   version "6.4.0"


### PR DESCRIPTION
This PR updates `<Stage />` component to work for both new and legacy Context APIs.

TODO:
- [x] fix unit tests
- [x] add tests for context provider

Fixes #71 