### PR TITLE
Fix context not passed through from primary renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed context not passed through from primary renderer (`react-dom`) into `react-pixi-fiber`
+
 
 ## [0.6.0] - 2018-11-10
 

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -70,7 +70,7 @@ class Stage extends React.Component {
     const stageProps = getDisplayObjectProps(this.props);
     applyProps(this._app.stage, {}, stageProps);
 
-    render(<AppProvider app={this._app}>{children}</AppProvider>, this._app.stage);
+    render(<AppProvider app={this._app}>{children}</AppProvider>, this._app.stage, undefined, this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -90,7 +90,7 @@ class Stage extends React.Component {
       this._app.renderer.resize(currentWidth, currentHeight);
     }
 
-    render(<AppProvider app={this._app}>{children}</AppProvider>, this._app.stage);
+    render(<AppProvider app={this._app}>{children}</AppProvider>, this._app.stage, undefined, this);
   }
 
   componentWillUnmount() {

--- a/src/render.js
+++ b/src/render.js
@@ -8,14 +8,14 @@ export const roots = new Map();
  * element should be any instance of PIXI DisplayObject
  * containerTag should be an instance of PIXI root Container (i.e. the Stage)
  */
-export function render(element, containerTag, callback) {
+export function render(element, containerTag, callback, parentComponent) {
   let root = roots.get(containerTag);
   if (!root) {
     root = ReactPixiFiber.createContainer(containerTag);
     roots.set(containerTag, root);
   }
 
-  ReactPixiFiber.updateContainer(element, root, undefined, callback);
+  ReactPixiFiber.updateContainer(element, root, parentComponent, callback);
 
   ReactPixiFiber.injectIntoDevTools({
     findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,

--- a/test/Stage.test.js
+++ b/test/Stage.test.js
@@ -176,7 +176,12 @@ describe("Stage", () => {
     const stage = instance._app.stage;
 
     expect(render).toHaveBeenCalledTimes(1);
-    expect(render).toHaveBeenCalledWith(<AppProvider app={instance._app}>{children}</AppProvider>, stage);
+    expect(render).toHaveBeenCalledWith(
+      <AppProvider app={instance._app}>{children}</AppProvider>,
+      stage,
+      undefined,
+      instance
+    );
   });
 
   it("calls render on componentDidUpdate", () => {
@@ -190,7 +195,12 @@ describe("Stage", () => {
     element.update(<Stage>{children2}</Stage>);
 
     expect(render).toHaveBeenCalledTimes(1);
-    expect(render).toHaveBeenCalledWith(<AppProvider app={instance._app}>{children2}</AppProvider>, stage);
+    expect(render).toHaveBeenCalledWith(
+      <AppProvider app={instance._app}>{children2}</AppProvider>,
+      stage,
+      undefined,
+      instance
+    );
   });
 
   it("calls unmount on componentWillUnmount", () => {


### PR DESCRIPTION
This was unintentionally introduced with #72, where `parentComponent` was not passed via `render` method used in `Stage` component to `updateContainer` call.

The issue surfaces for example when rendering with `react-dom` and trying to use `Provider` from `react-redux`, and then trying to `connect` PixiJS-based components to Redux store. This won't work as `store` will not be available in context once `ReactPixiFiber` kicks in.