### PR TITLE
Fix ReactPixiFiber#insertBefore

### DIFF
--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -105,14 +105,12 @@ export function removeChild(parentInstance, child) {
 export function insertBefore(parentInstance, child, beforeChild) {
   invariant(child !== beforeChild, "ReactPixiFiber cannot insert node before itself");
 
-  const childExists = parentInstance.children.indexOf(child) !== -1;
-  const index = parentInstance.getChildIndex(beforeChild);
-
-  if (childExists) {
-    parentInstance.setChildIndex(child, index);
-  } else {
-    parentInstance.addChildAt(child, index);
+  if (child.parent) {
+    child.parent.removeChild(child);
   }
+
+  const index = parentInstance.getChildIndex(beforeChild);
+  parentInstance.addChildAt(child, index);
 }
 
 export function commitUpdate(instance, updatePayload, type, lastRawProps, nextRawProps, internalInstanceHandle) {

--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -105,8 +105,10 @@ export function removeChild(parentInstance, child) {
 export function insertBefore(parentInstance, child, beforeChild) {
   invariant(child !== beforeChild, "ReactPixiFiber cannot insert node before itself");
 
-  if (child.parent) {
-    child.parent.removeChild(child);
+  const childExists = parentInstance.children.indexOf(child) !== -1;
+
+  if (childExists) {
+    parentInstance.removeChild(child);
   }
 
   const index = parentInstance.getChildIndex(beforeChild);

--- a/test/ReactPixiFiber.test.js
+++ b/test/ReactPixiFiber.test.js
@@ -196,9 +196,6 @@ describe("ReactPixiFiber", () => {
   });
 
   describe("insertBefore", () => {
-    const parent = {
-      getChildIndex: jest.fn(),
-    };
     const child1 = {
       idx: 0,
     };
@@ -210,34 +207,31 @@ describe("ReactPixiFiber", () => {
       jest.resetAllMocks();
     });
 
-    it("sets child index if child is already added to parent", () => {
+    it("adds child at specified index if child is already added to parent", () => {
       const parent = {
         addChildAt: jest.fn(),
+        removeChild: jest.fn(),
         children: [child1, child2],
         getChildIndex: jest.fn(child => child.idx),
-        setChildIndex: jest.fn(),
       };
 
       ReactPixiFiber.insertBefore(parent, child1, child2);
-      expect(parent.setChildIndex).toHaveBeenCalledTimes(1);
-      expect(parent.setChildIndex).toHaveBeenCalledWith(child1, child2.idx);
-
-      parent.setChildIndex.mockReset();
-
-      ReactPixiFiber.insertBefore(parent, child2, child1);
-      expect(parent.setChildIndex).toHaveBeenCalledTimes(1);
-      expect(parent.setChildIndex).toHaveBeenCalledWith(child2, child1.idx);
+      expect(parent.removeChild).toHaveBeenCalledTimes(1);
+      expect(parent.removeChild).toHaveBeenCalledWith(child1);
+      expect(parent.addChildAt).toHaveBeenCalledTimes(1);
+      expect(parent.addChildAt).toHaveBeenCalledWith(child1, child2.idx);
     });
 
     it("adds child at specified index if child is not already added to parent", () => {
       const parent = {
         addChildAt: jest.fn(),
+        removeChild: jest.fn(),
         children: [child2],
         getChildIndex: jest.fn(child => child.idx),
-        setChildIndex: jest.fn(),
       };
 
       ReactPixiFiber.insertBefore(parent, child1, child2);
+      expect(parent.removeChild).not.toHaveBeenCalled();
       expect(parent.addChildAt).toHaveBeenCalledTimes(1);
       expect(parent.addChildAt).toHaveBeenCalledWith(child1, child2.idx);
     });


### PR DESCRIPTION
parentInstance.setChildIndex removes child and adds it back at defined position. when child is before beforeChild index will be wrong. index - 1 would work, but then index will be wrong when child is after beforeChild.