### PR TITLE
Add shortcut type for Text anchor property.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ declare module 'react-pixi-fiber' {
 
   /** `Text` component properties */
   export interface TextProperties extends ChildlessComponent<PIXI.Text> {
-    anchor: number[];
+    anchor: number[] | PIXI.ObservablePoint;
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ declare module 'react-pixi-fiber' {
 
   /** `Text` component properties */
   export interface TextProperties extends ChildlessComponent<PIXI.Text> {
-    anchor: number[] | PIXI.ObservablePoint;
+    anchor?: number[] | PIXI.ObservablePoint;
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,8 +84,8 @@ declare module 'react-pixi-fiber' {
   export class Sprite extends React.Component<SpriteProperties> {}
 
   /** `Text` component properties */
-  export interface TextProperties extends ChildlessComponent<PIXI.Text> {
-    anchor?: number[] | PIXI.ObservablePoint;
+  export interface TextProperties extends ChildlessComponent<Omit<PIXI.Text, 'anchor'>> {
+    anchor?: string | number[] | PIXI.ObservablePoint;
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,9 @@ declare module 'react-pixi-fiber' {
   export class Sprite extends React.Component<SpriteProperties> {}
 
   /** `Text` component properties */
-  export interface TextProperties extends ChildlessComponent<PIXI.Text> {}
+  export interface TextProperties extends ChildlessComponent<PIXI.Text> {
+    anchor: number[];
+  }
 
   /**
    * A component wrapper for `PIXI.Text`.


### PR DESCRIPTION
Now anchor works using shortcut without typecasting to any:
```
<Text
  x={x}
  y={y}
  anchor={[0.5, 1]}
  text={text}
/>
```