### PR TITLE
fix: README Sprite example

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ class RotatingBunny extends Component {
     return (
       <Sprite 
         {...this.props}
-        texture={PIXI.Texture.fromImage(bunny)}
+        texture={PIXI.Texture.from(bunny)}
         rotation={this.state.rotation} 
       />
     );


### PR DESCRIPTION
Hi,

Looks like the method of `PIXI.Sprite` only has `from` now. 
Ref: http://pixijs.download/release/docs/PIXI.Sprite.html#.from

