### PR TITLE
Remove `package.json` references from bundled code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Removed
+- Removed `package.json` references from bundled code
+
 
 ## [0.8.0] - 2019-02-24
 

--- a/config/jest/setupGlobals.js
+++ b/config/jest/setupGlobals.js
@@ -1,0 +1,4 @@
+const pkg = require("../../package.json");
+
+global.__PACKAGE_NAME__ = pkg.name
+global.__PACKAGE_VERSION__ = pkg.version

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -1,3 +1,4 @@
+const pkg = require("../package.json");
 const json = require("rollup-plugin-json");
 const babel = require("rollup-plugin-babel");
 const commonjs = require("rollup-plugin-commonjs");
@@ -29,8 +30,10 @@ const getPlugins = entry => [
     exclude: "node_modules/**",
   }),
   replace({
-    __DEV__: isProduction ? "false" : "true",
-    "process.env.NODE_ENV": isProduction ? "'production'" : "'development'",
+    __DEV__: isProduction ? JSON.stringify(false) : JSON.stringify(true),
+    __PACKAGE_NAME__: JSON.stringify(pkg.name),
+    __PACKAGE_VERSION__: JSON.stringify(pkg.version),
+    "process.env.NODE_ENV": isProduction ? JSON.stringify("production") : JSON.stringify("development"),
   }),
   commonjs({
     ignoreGlobal: false,

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
       "__DEV__": true
     },
     "setupFiles": [
+      "./config/jest/setupGlobals.js",
       "./config/jest/setupPixi.js"
     ],
     "testEnvironment": "jest-environment-jsdom-with-canvas",

--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,3 @@
-import pkg from "../package.json";
 import invariant from "fbjs/lib/invariant";
 import { ReactPixiFiberAsPrimaryRenderer as ReactPixiFiber } from "../src/ReactPixiFiber";
 
@@ -20,8 +19,8 @@ export function render(element, containerTag, callback, parentComponent) {
   ReactPixiFiber.injectIntoDevTools({
     findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,
     bundleType: __DEV__ ? 1 : 0,
-    version: pkg.version,
-    rendererPackageName: pkg.name,
+    version: __PACKAGE_VERSION__,
+    rendererPackageName: __PACKAGE_NAME__,
   });
 
   return ReactPixiFiber.getPublicRootInstance(root);


### PR DESCRIPTION
`package.json` was unnecessarily included into output bundle. This change reduces bundle size.