### PR TITLE
Change 'render' to inject into dev tools once per 'containerTag'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Changed `render` to inject into dev tools once per `containerTag`
+
 
 ## [0.8.1] - 2019-05-29
 

--- a/src/render.js
+++ b/src/render.js
@@ -12,16 +12,16 @@ export function render(element, containerTag, callback, parentComponent) {
   if (!root) {
     root = ReactPixiFiber.createContainer(containerTag);
     roots.set(containerTag, root);
+
+    ReactPixiFiber.injectIntoDevTools({
+      findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,
+      bundleType: __DEV__ ? 1 : 0,
+      version: __PACKAGE_VERSION__,
+      rendererPackageName: __PACKAGE_NAME__,
+    });
   }
 
   ReactPixiFiber.updateContainer(element, root, parentComponent, callback);
-
-  ReactPixiFiber.injectIntoDevTools({
-    findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,
-    bundleType: __DEV__ ? 1 : 0,
-    version: __PACKAGE_VERSION__,
-    rendererPackageName: __PACKAGE_NAME__,
-  });
 
   return ReactPixiFiber.getPublicRootInstance(root);
 }


### PR DESCRIPTION
After changing `Stage` to use `render` method internally (in #72) in both `componentDidMount` and `componentDidUpdate` it looks like it was injected into dev tools with each render.