### PR TITLE
Fix renderer to be secondary when using <Stage /> component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed renderer to be secondary when using `<Stage />` component
+
 
 ## [0.9.0] - 2019-07-01
 

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -3,9 +3,12 @@ import PropTypes from "prop-types";
 import * as PIXI from "pixi.js";
 import { AppProvider } from "./AppProvider";
 import { DEFAULT_PROPS, EVENT_PROPS } from "./props";
-import { applyProps } from "./ReactPixiFiber";
-import { render, unmount } from "./render";
+import { ReactPixiFiberAsSecondaryRenderer, applyProps } from "./ReactPixiFiber";
+import { createRender, createUnmount } from "./render";
 import { filterByKey, including } from "./utils";
+
+const render = createRender(ReactPixiFiberAsSecondaryRenderer)
+const unmount = createUnmount(ReactPixiFiberAsSecondaryRenderer)
 
 export function validateCanvas(props, propName, componentName) {
   // Let's assume that element is canvas if the element is Element and implements getContext

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -7,8 +7,8 @@ import { ReactPixiFiberAsSecondaryRenderer, applyProps } from "./ReactPixiFiber"
 import { createRender, createUnmount } from "./render";
 import { filterByKey, including } from "./utils";
 
-const render = createRender(ReactPixiFiberAsSecondaryRenderer)
-const unmount = createUnmount(ReactPixiFiberAsSecondaryRenderer)
+const render = createRender(ReactPixiFiberAsSecondaryRenderer);
+const unmount = createUnmount(ReactPixiFiberAsSecondaryRenderer);
 
 export function validateCanvas(props, propName, componentName) {
   // Let's assume that element is canvas if the element is Element and implements getContext

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,22 @@ import { TYPES } from "./types";
 import { createRender, createUnmount } from "./render";
 import { ReactPixiFiberAsPrimaryRenderer, applyProps, unstable_batchedUpdates } from "./ReactPixiFiber";
 
-const render = createRender(ReactPixiFiberAsPrimaryRenderer)
-const unmount = createUnmount(ReactPixiFiberAsPrimaryRenderer)
+const render = createRender(ReactPixiFiberAsPrimaryRenderer);
+const unmount = createUnmount(ReactPixiFiberAsPrimaryRenderer);
 
 /* Public API */
 
-export { AppContext, AppProvider, CustomPIXIComponent, Stage, applyProps, render, unmount, withApp, unstable_batchedUpdates };
+export {
+  AppContext,
+  AppProvider,
+  CustomPIXIComponent,
+  Stage,
+  applyProps,
+  render,
+  unmount,
+  withApp,
+  unstable_batchedUpdates,
+};
 
 export const BitmapText = TYPES.BITMAP_TEXT;
 export const Container = TYPES.CONTAINER;

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,15 @@ import CustomPIXIComponent from "./CustomPIXIComponent";
 import { AppContext, AppProvider, withApp } from "./AppProvider";
 import Stage from "./Stage";
 import { TYPES } from "./types";
-import { render } from "./render";
-import { applyProps, unstable_batchedUpdates } from "./ReactPixiFiber";
+import { createRender, createUnmount } from "./render";
+import { ReactPixiFiberAsPrimaryRenderer, applyProps, unstable_batchedUpdates } from "./ReactPixiFiber";
+
+const render = createRender(ReactPixiFiberAsPrimaryRenderer)
+const unmount = createUnmount(ReactPixiFiberAsPrimaryRenderer)
 
 /* Public API */
 
-export { AppContext, AppProvider, CustomPIXIComponent, Stage, applyProps, render, withApp, unstable_batchedUpdates };
+export { AppContext, AppProvider, CustomPIXIComponent, Stage, applyProps, render, unmount, withApp, unstable_batchedUpdates };
 
 export const BitmapText = TYPES.BITMAP_TEXT;
 export const Container = TYPES.CONTAINER;

--- a/src/render.js
+++ b/src/render.js
@@ -10,7 +10,6 @@ export function createRender(ReactPixiFiber) {
   return function render(element, containerTag, callback, parentComponent) {
     let root = roots.get(containerTag);
     if (!root) {
-      // TODO should render secondary when Stage is rendering
       root = ReactPixiFiber.createContainer(containerTag);
       roots.set(containerTag, root);
 

--- a/src/render.js
+++ b/src/render.js
@@ -7,7 +7,7 @@ export const roots = new Map();
  * containerTag should be an instance of PIXI root Container (i.e. the Stage)
  */
 export function createRender(ReactPixiFiber) {
-  return function render (element, containerTag, callback, parentComponent) {
+  return function render(element, containerTag, callback, parentComponent) {
     let root = roots.get(containerTag);
     if (!root) {
       // TODO should render secondary when Stage is rendering
@@ -25,15 +25,15 @@ export function createRender(ReactPixiFiber) {
     ReactPixiFiber.updateContainer(element, root, parentComponent, callback);
 
     return ReactPixiFiber.getPublicRootInstance(root);
-  }
+  };
 }
 
 export function createUnmount(ReactPixiFiber) {
-  return function unmount (containerTag) {
+  return function unmount(containerTag) {
     const root = roots.get(containerTag);
 
     invariant(root, "ReactPixiFiber did not render into container provided");
 
     ReactPixiFiber.updateContainer(null, root);
-  }
+  };
 }

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,4 @@
 import invariant from "fbjs/lib/invariant";
-import { ReactPixiFiberAsPrimaryRenderer as ReactPixiFiber } from "../src/ReactPixiFiber";
 
 export const roots = new Map();
 
@@ -7,29 +6,34 @@ export const roots = new Map();
  * element should be any instance of PIXI DisplayObject
  * containerTag should be an instance of PIXI root Container (i.e. the Stage)
  */
-export function render(element, containerTag, callback, parentComponent) {
-  let root = roots.get(containerTag);
-  if (!root) {
-    root = ReactPixiFiber.createContainer(containerTag);
-    roots.set(containerTag, root);
+export function createRender(ReactPixiFiber) {
+  return function render (element, containerTag, callback, parentComponent) {
+    let root = roots.get(containerTag);
+    if (!root) {
+      // TODO should render secondary when Stage is rendering
+      root = ReactPixiFiber.createContainer(containerTag);
+      roots.set(containerTag, root);
 
-    ReactPixiFiber.injectIntoDevTools({
-      findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,
-      bundleType: __DEV__ ? 1 : 0,
-      version: __PACKAGE_VERSION__,
-      rendererPackageName: __PACKAGE_NAME__,
-    });
+      ReactPixiFiber.injectIntoDevTools({
+        findFiberByHostInstance: ReactPixiFiber.findFiberByHostInstance,
+        bundleType: __DEV__ ? 1 : 0,
+        version: __PACKAGE_VERSION__,
+        rendererPackageName: __PACKAGE_NAME__,
+      });
+    }
+
+    ReactPixiFiber.updateContainer(element, root, parentComponent, callback);
+
+    return ReactPixiFiber.getPublicRootInstance(root);
   }
-
-  ReactPixiFiber.updateContainer(element, root, parentComponent, callback);
-
-  return ReactPixiFiber.getPublicRootInstance(root);
 }
 
-export function unmount(containerTag) {
-  const root = roots.get(containerTag);
+export function createUnmount(ReactPixiFiber) {
+  return function unmount (containerTag) {
+    const root = roots.get(containerTag);
 
-  invariant(root, "ReactPixiFiber did not render into container provided");
+    invariant(root, "ReactPixiFiber did not render into container provided");
 
-  ReactPixiFiber.updateContainer(null, root);
+    ReactPixiFiber.updateContainer(null, root);
+  }
 }

--- a/test/AppProvider.test.js
+++ b/test/AppProvider.test.js
@@ -1,10 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
-import renderer from "react-test-renderer";
 import { AppContext, AppProvider, Container, Stage, withApp } from "../src";
-import { render } from "../src/render";
+import { ReactPixiFiberAsPrimaryRenderer as ReactPixiFiber } from "../src/ReactPixiFiber";
+import { createRender } from "../src/render";
 import * as PIXI from "pixi.js";
+
+const render = createRender(ReactPixiFiber)
 
 if (typeof React.createContext === "function") {
   // New Context API

--- a/test/ReactPixiFiber.test.js
+++ b/test/ReactPixiFiber.test.js
@@ -3,7 +3,7 @@ import emptyObject from "fbjs/lib/emptyObject";
 import * as PIXI from "pixi.js";
 import * as ReactPixiFiber from "../src/ReactPixiFiber";
 import { __RewireAPI__ as ReactPixiFiberRewireAPI } from "../src/ReactPixiFiber";
-import { render } from "../src/render";
+import { createRender } from "../src/render";
 import { DEFAULT_PROPS } from "../src/props";
 import { TYPES } from "../src/types";
 import * as utils from "../src/utils";
@@ -498,6 +498,7 @@ describe("ReactPixiFiber", () => {
 
   describe("unstable_batchedUpdates", () => {
     it("should render one time when call setState many times", () => {
+      const render = createRender(ReactPixiFiber.ReactPixiFiberAsPrimaryRenderer)
       const app = new PIXI.Application();
       const root = app.stage;
       const nextState = {};

--- a/test/Stage.test.js
+++ b/test/Stage.test.js
@@ -2,7 +2,6 @@ import React from "react";
 import renderer from "react-test-renderer";
 import * as PIXI from "pixi.js";
 import { Text } from "../src/index";
-import ReactPixiFiber from "../src/ReactPixiFiber";
 import Stage, {
   getCanvasProps,
   getDisplayObjectProps,
@@ -11,7 +10,6 @@ import Stage, {
   includingStageProps,
   validateCanvas,
 } from "../src/Stage";
-import { render, unmount } from "../src/render";
 import { AppProvider } from "../src/AppProvider";
 import { DEFAULT_PROPS, EVENT_PROPS } from "../src/props";
 
@@ -23,13 +21,20 @@ jest.mock("../src/ReactPixiFiber", () => {
   });
 });
 jest.mock("../src/render", () => {
+  const render = jest.fn();
+  const unmount = jest.fn();
+
   return {
-    render: jest.fn(),
-    unmount: jest.fn(),
+    createRender: jest.fn().mockReturnValue(render),
+    createUnmount: jest.fn().mockReturnValue(unmount),
+    __renderMock: render,
+    __unmounMock: unmount,
   };
 });
 
 describe("Stage", () => {
+  const { __renderMock, __unmounMock } = require("../src/render");
+
   it("renders canvas element", () => {
     const tree = renderer.create(<Stage />).toJSON();
 
@@ -169,14 +174,14 @@ describe("Stage", () => {
   });
 
   it("calls render on componentDidMount", () => {
-    render.mockClear();
+    __renderMock.mockClear();
     const children = <Text text="Hello World!" />;
     const element = renderer.create(<Stage>{children}</Stage>);
     const instance = element.getInstance();
     const stage = instance._app.stage;
 
-    expect(render).toHaveBeenCalledTimes(1);
-    expect(render).toHaveBeenCalledWith(
+    expect(__renderMock).toHaveBeenCalledTimes(1);
+    expect(__renderMock).toHaveBeenCalledWith(
       <AppProvider app={instance._app}>{children}</AppProvider>,
       stage,
       undefined,
@@ -190,12 +195,12 @@ describe("Stage", () => {
     const instance = element.getInstance();
     const stage = instance._app.stage;
 
-    render.mockClear();
+    __renderMock.mockClear();
     const children2 = <Text text="World Hello!" />;
     element.update(<Stage>{children2}</Stage>);
 
-    expect(render).toHaveBeenCalledTimes(1);
-    expect(render).toHaveBeenCalledWith(
+    expect(__renderMock).toHaveBeenCalledTimes(1);
+    expect(__renderMock).toHaveBeenCalledWith(
       <AppProvider app={instance._app}>{children2}</AppProvider>,
       stage,
       undefined,
@@ -207,11 +212,11 @@ describe("Stage", () => {
     const element = renderer.create(<Stage />);
     const instance = element.getInstance();
     const stage = instance._app.stage;
-    unmount.mockClear();
+    __unmounMock.mockClear();
     element.unmount();
 
-    expect(unmount).toHaveBeenCalledTimes(1);
-    expect(unmount).toHaveBeenCalledWith(stage);
+    expect(__unmounMock).toHaveBeenCalledTimes(1);
+    expect(__unmounMock).toHaveBeenCalledWith(stage);
   });
 });
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import pkg from "../package.json";
 import { Container, Text } from "../src/index";
 import { ReactPixiFiberAsPrimaryRenderer as ReactPixiFiber } from "../src/ReactPixiFiber";
-import { render, roots, unmount } from "../src/render";
+import { createRender, createUnmount, roots } from "../src/render";
 import * as PIXI from 'pixi.js'
 
 jest.mock("../src/ReactPixiFiber", () => {
@@ -22,6 +22,7 @@ describe("render", () => {
     jest.resetAllMocks();
   });
 
+  const render = createRender(ReactPixiFiber)
   const app = new PIXI.Application();
   const callback = jest.fn();
   const root = app.stage;
@@ -73,6 +74,7 @@ describe("unmount", () => {
     jest.resetAllMocks();
   });
 
+  const unmount = createUnmount(ReactPixiFiber)
   const app = new PIXI.Application();
   const root = app.stage;
 


### PR DESCRIPTION
This was unintentionally introduced with #72, where `render` method used in `Stage` component was always using `isPrimaryRenderer` being `true`.

The issue surfaces for example when using the same Context Provider in both `ReactDOM` and `ReactPixiFiber`.