### PR TITLE
Fix copyPoint to use copyFrom in pixi v5 properly

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -55,13 +55,12 @@ export function isPointType(value) {
   return value instanceof PIXI.Point || value instanceof PIXI.ObservablePoint;
 }
 
-// Point.copy was deprecated and renamed to copyForm in PIXI 5.0,
-// use whichever exists
+// Use Point.copyFrom if available because Point.copy was deprecated in PIXI 5.0
 export function copyPoint(instance, propName, value) {
-  if (typeof instance[propName].copy === "function") {
-    instance[propName].copy(value);
-  } else {
+  if (typeof instance[propName].copyFrom === "function") {
     instance[propName].copyFrom(value);
+  } else {
+    instance[propName].copy(value);
   }
 }
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -180,7 +180,8 @@ describe("setPixiValue", () => {
 // this test should probably be updated test for existance of copyForm instead.
 describe("copyPoint", () => {
   const PixiJSv4Point = { copy: jest.fn() };
-  const PixiJSv5Point = { copyFrom: jest.fn() };
+  // Method Point.copy is still available in PixiJS v5 but it is deprecated
+  const PixiJSv5Point = { copy: jest.fn(), copyFrom: jest.fn() };
 
   it("copies value using copy method when using PixiJS v4", () => {
     const instance = {
@@ -200,6 +201,7 @@ describe("copyPoint", () => {
     const position = new PIXI.Point(13, 37);
 
     copyPoint(instance, "position", position);
+    expect(PixiJSv5Point.copy).not.toHaveBeenCalled();
     expect(PixiJSv5Point.copyFrom).toHaveBeenCalledTimes(1);
     expect(PixiJSv5Point.copyFrom).toHaveBeenCalledWith(position);
   });


### PR DESCRIPTION
copyPoint does not work as intended in pixi v5. It looks for Point.copy and use it if available. Unfortunately function copy is still available in pixi v5 as an empty function:

http://pixijs.download/release/docs/PIXI.Point.html#copy

It causes that in pixi v5 copyPoint uses Point.copy instead of new Point.copyFrom.
I encountered this problem when I tried to use pixijs v5 and react-pixi-fiber with pixi-projection.

https://codesandbox.io/s/react-pixi-fiber-with-pixi-projection-broken-rotating-bunny-lcl6e