### PR TITLE
fix: child components cannot be destroy

### DIFF
--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -105,7 +105,7 @@ export function removeChild(parentInstance, child) {
 
   parentInstance.removeChild(child);
 
-  child.destroy();
+  child.destroy({ children: true });
 }
 
 export function insertBefore(parentInstance, child, beforeChild) {

--- a/test/ReactPixiFiber.test.js
+++ b/test/ReactPixiFiber.test.js
@@ -248,7 +248,7 @@ describe("ReactPixiFiber", () => {
       ReactPixiFiber.removeChild(parent, child);
 
       expect(child.destroy).toHaveBeenCalledTimes(1);
-      expect(child.destroy).toHaveBeenCalledWith();
+      expect(child.destroy).toHaveBeenCalledWith({ children: true });
     });
 
     it("delegates custom detach to child if _customWillDetach is defined", () => {


### PR DESCRIPTION
`.destroy` method provides corresponding parameters for unloading nested child components. This will cause the DOM Nodes to keep growing and cannot be destroyed normally when using the `Text` component