### PR TITLE
Fix type definitions for CustomPIXIComponents and add missing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added missing type definitions
+
+### Fixed
+- Fixed type definitions for `CustomPIXIComponents`
+
 
 ## [0.12.2] - 2020-01-20
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,186 +1,227 @@
 import * as React from "react";
 import * as PIXI from "pixi.js";
-import { InteractiveComponent } from "react-pixi-fiber";
 
 declare module "react-pixi-fiber" {
-  /** The shape of `T` without it's `children` property. */
-  export type Childless<T> = Partial<Omit<T, "children">>;
+  /**
+   * Helpers
+   */
 
-  /** The shape of a component that has an optional `children` property. */
-  export interface ReactChildrenProperties {
-    children?: React.ReactNode;
-  }
+  // The shape of `T` without it's `children` property.
+  type Childless<T> = Partial<Omit<T, "children">>;
 
-  /** The shape of a component that has app `property` that is an instance of PIXI.Application */
-  export interface PixiAppProperties {
-    app: PIXI.Application;
-  }
+  // Returns optional keys of `T`
+  type OptionalKeys<T> = { [K in keyof T]-?: {} extends Pick<T, K> ? K : never }[keyof T];
+  // Returns required keys of `T`
+  type RequiredKeys<T> = { [K in keyof T]-?: {} extends Pick<T, K> ? never : K }[keyof T];
+  // Returns keys `K` of `T` where `T[K]` is of type `U`
+  type KeysOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
 
-  /** Point like object with x,y */
-  interface PointLikeObject {
+  // Constructs a type by picking the set of optional properties `T`.
+  type OptionalProperties<T> = Pick<T, OptionalKeys<T>>;
+  // Constructs a type by picking the set of required properties `T`.
+  type RequiredProperties<T> = Pick<T, RequiredKeys<T>>;
+
+  /**
+   * Points
+   */
+
+  // Point-like object with `x`, `y` keys.
+  // e.g. `position={{ x: 13, y: 37 }}`
+  export interface PointLikeObject {
     x: number;
     y: number;
   }
 
-  /** Point like type */
-  type PointLike = PIXI.Point | PIXI.ObservablePoint | PointLikeObject | string | [number, number];
+  // Point-like tuple with `x` and `y` encoded as a single value or provided as a separate values.
+  // e.g. `pivot={[13, 37]}`
+  export type PointLikeTuple = [number, number];
 
-  /** Create new type based on O with replaced T properties by K */
-  type WithElements<O, T extends keyof any, K> = Omit<O, T> & { [P in T]?: K };
+  // Point-like number with `x` and `y` encoded  as a single value
+  // e.g. `scale={2}`
+  export type PointLikeNumber = number;
 
-  /** Replace P properties to point like */
-  type WithPointLike<T, P extends keyof any> = WithElements<Childless<T>, P, PointLike>;
+  // Point-like string with `x` and `y` separated by a comma
+  // e.g. `anchor="1,0.5"`
+  export type PointLikeString = string;
+
+  // Point-like type
+  export type PointLike = PIXI.IPoint | PointLikeObject | PointLikeTuple | PointLikeNumber | PointLikeString;
+
+  // Properties of `T` that extend `PIXI.IPoint` interface
+  export type PointProperties<T> = Extract<keyof T, KeysOfType<Required<T>, PIXI.IPoint>>;
+
+  // Replace type of properties declared in `T` as `PIXI.IPoint` to `PointLike`.
+  export type WithPointLike<T> =
+    // Omit all properties declared it `T` as `PIXI.IPoint`.
+    Omit<T, PointProperties<T>> &
+      // Pick all required point properties from `T` with type changed to `PointLike` and make sure they are still required.
+      Pick<{ [U in PointProperties<RequiredProperties<T>>]: PointLike }, PointProperties<RequiredProperties<T>>> &
+      // Pick all optional point properties from `T` with type changed to `PointLike` and make sure they are still optional.
+      Pick<{ [U in PointProperties<OptionalProperties<T>>]?: PointLike }, PointProperties<OptionalProperties<T>>>;
 
   /**
-   * Extra properties to add to allow us to set event handlers using props
+   * Interactivity
    */
+
+  // Extra properties to add to allow us to set event handlers using props.
   export type InteractiveComponent = {
     [P in PIXI.interaction.InteractionEventTypes]?: (event: PIXI.interaction.InteractionEvent) => void
   };
 
-  export type WithInteractive<T> = T & InteractiveComponent;
+  /**
+   * Base components
+   */
+
+  // Takes `PIXI.DisplayObject` or its subclass and updates its fields to be used with `ReactPixiFiber`.
+  export type DisplayObjectProperties<T> = WithPointLike<Childless<T>> & InteractiveComponent;
+
+  // A component wrapper for `PIXI.BitmapText`.
+  // see: http://pixijs.download/dev/docs/PIXI.BitmapText.html
+  export class BitmapText extends React.Component<DisplayObjectProperties<PIXI.BitmapText>> {}
+
+  // A component wrapper for `PIXI.Container`.
+  // see: http://pixijs.download/dev/docs/PIXI.Container.html
+  export class Container extends React.Component<DisplayObjectProperties<PIXI.Container>> {}
+
+  // A component wrapper for `PIXI.Graphics`.
+  // see: http://pixijs.download/dev/docs/PIXI.Graphics.html
+  export class Graphics extends React.Component<DisplayObjectProperties<PIXI.Graphics>> {}
+
+  // A component wrapper for `PIXI.ParticleContainer`.
+  // see: http://pixijs.download/dev/docs/PIXI.ParticleContainer.html
+  export class ParticleContainer extends React.Component<DisplayObjectProperties<PIXI.ParticleContainer>> {}
+
+  // A component wrapper for `PIXI.Sprite`.
+  // see: http://pixijs.download/dev/docs/PIXI.Sprite.html
+  export class Sprite extends React.Component<DisplayObjectProperties<PIXI.Sprite>> {}
+
+  // A component wrapper for `PIXI.Text`.
+  // see: http://pixijs.download/dev/docs/PIXI.Text.html
+  export class Text extends React.Component<DisplayObjectProperties<PIXI.Text>> {}
+
+  // A component wrapper for `PIXI.TilingSprite`.
+  // see: http://pixijs.download/dev/docs/PIXI.TilingSprite.html
+  export class TilingSprite extends React.Component<DisplayObjectProperties<PIXI.TilingSprite>> {}
 
   /**
-   * A PIXI Component with children.
+   * Rendering: using Stage component or using render and unmount
    */
-  export type Component<T> = Childless<T> & ReactChildrenProperties;
 
-  type ContainerPointProperties = "position" | "scale" | "pivot";
-  type SpritePointProperties = ContainerPointProperties | "anchor";
-  type BitmapTextPointProperties = ContainerPointProperties | "anchor";
-  type TextPointProperties = ContainerPointProperties | "anchor";
-
-  /** `BitmapText` component properties. */
-  export type BitmapTextProperties = WithInteractive<WithPointLike<PIXI.BitmapText, BitmapTextPointProperties>>;
-
-  /** `Container` component properties. */
-  export type ContainerProperties = WithInteractive<WithPointLike<PIXI.Container, ContainerPointProperties>>;
-
-  /** `ParticleContainer` component properties. */
-  export type ParticleContainerProperties = WithInteractive<WithPointLike<PIXI.ParticleContainer, ContainerPointProperties>>;
-
-  /** `Graphics` component properties. */
-  export type GraphicsProperties = WithInteractive<WithPointLike<PIXI.Graphics, ContainerPointProperties>>;
-
-  /** `Sprite` component properties. */
-  export type SpriteProperties = WithInteractive<WithPointLike<PIXI.Sprite, SpritePointProperties>>;
-
-  /** `TilingSprite` component properties. */
-  export type TilingSpriteProperties = WithInteractive<WithPointLike<PIXI.TilingSprite, SpritePointProperties>>;
-
-  /** `Text` component properties */
-  export type TextProperties = WithInteractive<WithPointLike<PIXI.Text, TextPointProperties>>;
-
-  /** `Stage` component properties." */
-  export interface StageProperties extends WithInteractive<WithPointLike<PIXI.Container, ContainerPointProperties>> {
-    options?: {};
+  interface StagePropertiesWithApp {
+    app: PIXI.Application;
+    options?: never;
+  }
+  interface StagePropertiesWithOptions {
+    app?: never;
+    options: ConstructorParameters<typeof PIXI.Application>[0];
   }
 
-  /**
-   * A component wrapper for `PIXI.BitmapText`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.extras.BitmapText.html
-   */
-  export class BitmapText extends React.Component<BitmapTextProperties> {}
+  // Allow either `app` or `options` passed to `Stage`.
+  export type StageProperties = (StagePropertiesWithApp | StagePropertiesWithOptions) &
+    React.CanvasHTMLAttributes<HTMLCanvasElement>;
 
-  /**
-   * A component wrapper for `PIXI.Container`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Container.html
-   */
-  export class Container extends React.Component<ContainerProperties> {}
-
-  /**
-   * A component wrapper for `PIXI.Graphics`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Graphics.html
-   */
-  export class Graphics extends React.Component<GraphicsProperties> {}
-
-  /**
-   * A component wrapper for `PIXI.ParticleContainer`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.ParticleContainer.html
-   */
-  export class ParticleContainer extends React.Component<TilingSpriteProperties> {}
-
-  /**
-   * A component wrapper for `PIXI.Sprite`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Sprite.html
-   */
-  export class Sprite extends React.Component<SpriteProperties> {}
-
-  /**
-   * A component wrapper for `PIXI.Text`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Text.html
-   */
-  export class Text extends React.Component<TextProperties> {}
-
-  /**
-   * A component wrapper for `PIXI.TilingSprite`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.TilingSprite.html
-   */
-  export class TilingSprite extends React.Component<TilingSpriteProperties> {}
-
-  /**
-   * A component wrapper for PIXI `Stage`.
-   *
-   * see: http://pixijs.download/dev/docs/PIXI.Application.html
-   */
+  // A component wrapper for PIXI `Stage`.
+  // see: http://pixijs.download/dev/docs/PIXI.Application.html
   export class Stage extends React.Component<StageProperties> {}
+  export function createStageClass(): React.ComponentType<StageProperties>;
 
-  /** Custom React Reconciler render method. */
+  // Standalone ReactPixiFiber render method.
   export function render(
     pixiElement: React.ReactElement<any> | React.ReactElement<any>[] | PIXI.DisplayObject | PIXI.DisplayObject[],
     stage: PIXI.Container,
     callback?: Function
   ): void;
+  // Standalone ReactPixiFiber unmount method.
+  export function unmount(stage: PIXI.Container): void;
 
   /**
-   * Custom component properties.
+   * Custom components
    */
-  export interface Behavior<T, U extends PIXI.DisplayObject> {
-    /**
-     * Use this to create an instance of [PIXI.DisplayObject].
-     */
-    customDisplayObject: (props: T) => U;
-    /**
-     * Use this to apply newProps to your Component in a custom way.
-     */
-    customApplyProps?: (displayObject: U, oldProps: T, newProps: T) => void;
-    /**
-     * Use this to do something after displayObject is attached, which happens after componentDidMount lifecycle method.
-     */
-    customDidAttach?: (displayObject: U) => void;
-    /**
-     * Use this to do something (usually cleanup) before detaching, which happens before componentWillUnmount lifecycle method.
-     */
-    customWillDetach?: (displayObject: U) => void;
+
+  // Used create an instance of `PIXI.DisplayObject`.
+  // Also used as a `CustomPIXIComponent` `behavior` factory function.
+  export type CustomDisplayObjectCreator<DisplayObject extends PIXI.DisplayObject, Props> = (
+    props: Props
+  ) => CustomDisplayObject<DisplayObject, Props>;
+
+  // Used to apply `newProps` to your `CustomPIXIComponent` in a custom way.
+  export type CustomDisplayObjectPropSetter<DisplayObject extends PIXI.DisplayObject, Props> = (
+    displayObject: DisplayObject,
+    oldProps: Props,
+    newProps: Props
+  ) => void;
+
+  // Used to do something after `displayObject` is attached, which happens after `componentDidMount` lifecycle method.
+  export type CustomDisplayObjectAttachHandler<DisplayObject extends PIXI.DisplayObject> = (
+    displayObject: DisplayObject
+  ) => void;
+
+  // Used to do something (usually cleanup) before detaching `displayObject`, which happens before `componentWillUnmount` lifecycle method.
+  export type CustomDisplayObjectDetachHandler<DisplayObject extends PIXI.DisplayObject> = (
+    displayObject: DisplayObject
+  ) => void;
+
+  // Inject API adds `_customApplyProps`, `_customDidAttach`, `_customWillDetach` methods.
+  export interface CustomDisplayObject<DisplayObject extends PIXI.DisplayObject, Props> extends PIXI.DisplayObject {
+    _customApplyProps?: CustomDisplayObjectPropSetter<DisplayObject, Props>;
+    _customDidAttach?: CustomDisplayObjectAttachHandler<DisplayObject>;
+    _customWillDetach?: CustomDisplayObjectDetachHandler<DisplayObject>;
   }
-  /**
-   * Create a custom component.
-   */
-  export function CustomPIXIComponent<T, U extends WithInteractive<PIXI.DisplayObject>> (
-    behavior: Behavior<T, U>,
-    /**
-     * The name of this custom component.
-     */
+
+  // `CustomPIXIComponent` `behavior` object.
+  export interface CustomPIXIComponentBehaviorDefinition<DisplayObject extends PIXI.DisplayObject, Props> {
+    customDisplayObject: CustomDisplayObjectCreator<DisplayObject, Props>;
+    customApplyProps?: CustomDisplayObjectPropSetter<DisplayObject, Props>;
+    customDidAttach?: CustomDisplayObjectAttachHandler<DisplayObject>;
+    customWillDetach?: CustomDisplayObjectDetachHandler<DisplayObject>;
+  }
+
+  // `CustomPIXIComponent` has `behavior` defined either as an object or factory function.
+  export type CustomPIXIComponentBehavior<DisplayObject extends PIXI.DisplayObject, Props> =
+    | CustomPIXIComponentBehaviorDefinition<DisplayObject, Props>
+    | CustomDisplayObjectCreator<DisplayObject, Props>;
+
+  // Create a custom component.
+  export function CustomPIXIComponent<DisplayObject extends PIXI.DisplayObject, Props>(
+    behavior: CustomPIXIComponentBehavior<DisplayObject, Props>,
     type: string
-  ): React.ReactType<T>;
+  ): React.ComponentType<Props & Omit<DisplayObjectProperties<DisplayObject>, keyof Props>>;
+
+  // Used to apply `newProps` to your `DisplayObject`.
+  export type applyProps<DisplayObject extends PIXI.DisplayObject, Props> = (
+    displayObject: DisplayObject,
+    oldProps: Props,
+    newProps: Props
+  ) => void;
 
   /**
-   * AppContext
+   * `PIXI.Application` context.
    */
-  export const AppContext: React.Context<PIXI.Application>;
 
-  const withApp: <T extends PixiAppProperties>(WrappedComponent: React.ComponentType<T>) => React.ComponentType<T>;
+  export type AppContext = React.Context<PIXI.Application>;
+
+  // `withApp` higher-order component that injects `app` property of `PIXI.Application` type to your component.
+  // You can use `interface ComponentProps extends PixiAppProperties {}` with component wrapped by `withApp`.
+  export interface PixiAppProperties {
+    app: PIXI.Application;
+  }
+  export function withApp<P extends PixiAppProperties>(
+    Component: React.ComponentType<P>
+  ): React.ComponentType<Omit<P, keyof PixiAppProperties>>;
 
   /**
-   * BatchedUpdates same as ReactDOM
+   * Hooks
    */
+
+  export function usePixiApp(): PIXI.Application;
+  export function usePixiTicker(callback: (deltaTime: number) => void): void;
+
+  /**
+   * Batched updates
+   */
+
+  // BatchedUpdates same as ReactDOM.
+  // see: https://github.com/AlexGalays/typescript-example/blob/5de2b59ba1984c41d24f022e1675f07c6015be5a/typings/react/react-dom.d.ts#L30
   export function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
   export function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
   export function unstable_batchedUpdates(callback: () => any): void;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import CustomPIXIComponent from "./CustomPIXIComponent";
 import { AppContext, AppProvider, withApp } from "./AppProvider";
 import Stage, { createStageClass } from "./Stage";
 import { TYPES } from "./types";
-import { usePixiApp, usePixiTicker, usePreviousProps, usePixiAppCreator } from "./hooks";
+import { usePixiApp, usePixiTicker, usePixiAppCreator } from "./hooks";
 import { createRender, createUnmount } from "./render";
 import { ReactPixiFiberAsPrimaryRenderer, applyProps, unstable_batchedUpdates } from "./ReactPixiFiber";
 

--- a/test/typescript/index.tsx
+++ b/test/typescript/index.tsx
@@ -1,5 +1,5 @@
-import * as PIXI from 'pixi.js';
-import * as React from 'react';
+import * as PIXI from "pixi.js";
+import * as React from "react";
 import {
   BitmapText,
   Container,
@@ -9,12 +9,12 @@ import {
   Stage,
   Text,
   TilingSprite,
-  CustomPIXIComponent
-} from 'react-pixi-fiber';
+  CustomPIXIComponent,
+} from "react-pixi-fiber";
 
 const anchor = new PIXI.ObservablePoint(() => {}, undefined, 0.5, 0.5);
 
-const texture = PIXI.Texture.from('https://i.imgur.com/IaUrttj.png');
+const texture = PIXI.Texture.from("https://i.imgur.com/IaUrttj.png");
 
 const CompositionExample: React.SFC = () => (
   <Container>
@@ -22,23 +22,26 @@ const CompositionExample: React.SFC = () => (
   </Container>
 );
 
-const AnimatedSprite: React.ReactType = CustomPIXIComponent({
-  customDisplayObject: (props: any) => new PIXI.AnimatedSprite(props.textures),
-  customApplyProps: (animatedSprite: PIXI.AnimatedSprite, oldProps: any, newProps: any) => {},
-  customDidAttach: (animatedSprite: PIXI.AnimatedSprite) => {},
-  customWillDetach: (animatedSprite: PIXI.AnimatedSprite) => {},
-}, 'AnimatedSprite');
+const AnimatedSprite: React.ReactType = CustomPIXIComponent(
+  {
+    customDisplayObject: (props: any) => new PIXI.AnimatedSprite(props.textures),
+    customApplyProps: (animatedSprite: PIXI.AnimatedSprite, oldProps: any, newProps: any) => {},
+    customDidAttach: (animatedSprite: PIXI.AnimatedSprite) => {},
+    customWillDetach: (animatedSprite: PIXI.AnimatedSprite) => {},
+  },
+  "AnimatedSprite"
+);
 const CustomPIXIComponentExample: React.SFC = () => <AnimatedSprite />;
 
 const StageExample: React.SFC = () => (
-  <Stage options={{backgroundColor: 0xffffff}}>
+  <Stage options={{ backgroundColor: 0xffffff }}>
     <BitmapText text="" />
     <Container>
       <BitmapText text="" />
     </Container>
     <Graphics />
-    <ParticleContainer texture={texture}>
-    <BitmapText text="" />
+    <ParticleContainer autoResize={false}>
+      <Sprite texture={PIXI.Texture.WHITE} />
     </ParticleContainer>
     <Sprite anchor={anchor} texture={texture} />
     <Text />


### PR DESCRIPTION
This PR fixes issue reported in [#109](https://github.com/michalochman/react-pixi-fiber/pull/109#issuecomment-575937617), but I basically rewrote `index.d.ts` file completely, because there were many issues as well as missing types.

Notable changes:
- public API of `react-pixi-fiber` is now fully typed 🎉 
- components created by [`CustomPIXIComponent`](https://github.com/michalochman/react-pixi-fiber#custom-components) should now be correctly inspected by typescript –  they combine their own props with props available to their underlying `PIXI.DisplayObjects` (what they return in [`customDisplayObject`](https://github.com/michalochman/react-pixi-fiber#customdisplayobjectprops) factory)
- there are no hardcoded props (or events) for built-in components so the types should be resilient to updates to PixiJS unless major breaking changes are introduced