### PR TITLE
Fix type definitions for Stage to be able to use refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed type definitions for `CustomPIXIComponents`
+- Fixed type definitions for `Stage` to be able to use `ref`s
 
 
 ## [0.12.2] - 2020-01-20

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,11 @@ declare module "react-pixi-fiber" {
    * Base components
    */
 
+  // Allow components to have refs
+  interface ComponentWithRef {
+    ref?: React.Ref<React.ReactNode>;
+  }
+
   // Takes `PIXI.DisplayObject` or its subclass and updates its fields to be used with `ReactPixiFiber`.
   export type DisplayObjectProperties<T> = WithPointLike<Childless<T>> & InteractiveComponent;
 
@@ -118,7 +123,8 @@ declare module "react-pixi-fiber" {
 
   // Allow either `app` or `options` passed to `Stage`.
   export type StageProperties = (StagePropertiesWithApp | StagePropertiesWithOptions) &
-    React.CanvasHTMLAttributes<HTMLCanvasElement>;
+    React.CanvasHTMLAttributes<HTMLCanvasElement> &
+    ComponentWithRef;
 
   // A component wrapper for PIXI `Stage`.
   // see: http://pixijs.download/dev/docs/PIXI.Application.html

--- a/test/typescript/index.tsx
+++ b/test/typescript/index.tsx
@@ -16,7 +16,7 @@ const anchor = new PIXI.ObservablePoint(() => {}, undefined, 0.5, 0.5);
 
 const texture = PIXI.Texture.from("https://i.imgur.com/IaUrttj.png");
 
-const CompositionExample: React.SFC = () => (
+const CompositionExample: React.FC = () => (
   <Container>
     <BitmapText text="" />
   </Container>
@@ -31,21 +31,26 @@ const AnimatedSprite: React.ReactType = CustomPIXIComponent(
   },
   "AnimatedSprite"
 );
-const CustomPIXIComponentExample: React.SFC = () => <AnimatedSprite />;
+const CustomPIXIComponentExample: React.FC = () => <AnimatedSprite />;
 
-const StageExample: React.SFC = () => (
-  <Stage options={{ backgroundColor: 0xffffff }}>
-    <BitmapText text="" />
-    <Container>
+const StageExample: React.FC = () => {
+  const stageRef = React.useRef(null);
+  const spriteRef = React.useRef(null);
+
+  return (
+    <Stage options={{ backgroundColor: 0xffffff }} ref={stageRef}>
       <BitmapText text="" />
-    </Container>
-    <Graphics />
-    <ParticleContainer autoResize={false}>
-      <Sprite texture={PIXI.Texture.WHITE} />
-    </ParticleContainer>
-    <Sprite anchor={anchor} texture={texture} />
-    <Text />
-    <TilingSprite texture={texture} />
-    <CompositionExample />
-  </Stage>
-);
+      <Container>
+        <BitmapText text="" />
+      </Container>
+      <Graphics />
+      <ParticleContainer autoResize={false}>
+        <Sprite texture={PIXI.Texture.WHITE} />
+      </ParticleContainer>
+      <Sprite anchor={anchor} texture={texture} ref={spriteRef} />
+      <Text />
+      <TilingSprite texture={texture} />
+      <CompositionExample />
+    </Stage>
+  );
+};


### PR DESCRIPTION
Without this change it was impossible to use `ref` on `Stage`, i.e.:

```Property 'ref' does not exist on type 'IntrinsicAttributes & StagePropertiesWithOptions & CanvasHTMLAttributes<HTMLCanvasElement> & ComponentWithRef & { ...; }'.  TS2769```