### PR TITLE
Fix type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added `style` prop to `BitmapText` type
+
+### Fixed
+- Fixed type definitions to work with both PixiJS v4 and v5
+- Fixed type definitions for properties of type `any` being replaced with `PointLike`
+- Fixed type definitions for built-in components to be able to use `ref`s
+
 
 ## [0.12.3] - 2020-01-28
 

--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -142,10 +142,18 @@ export function createInstance(type, props, internalInstanceHandle) {
 
   switch (type) {
     case TYPES.BITMAP_TEXT:
+      const style =
+        typeof props.style !== "undefined"
+          ? props.style
+          : {
+              align: props.align,
+              font: props.font,
+              tint: props.tint,
+            };
       try {
-        instance = new PIXI.extras.BitmapText(props.text, props.style);
+        instance = new PIXI.extras.BitmapText(props.text, style);
       } catch (e) {
-        instance = new PIXI.BitmapText(props.text, props.style);
+        instance = new PIXI.BitmapText(props.text, style);
       }
       break;
     case TYPES.CONTAINER:

--- a/test/ReactPixiFiber.test.js
+++ b/test/ReactPixiFiber.test.js
@@ -360,10 +360,24 @@ describe("ReactPixiFiber", () => {
       jest.resetAllMocks();
     });
 
-    it("returns PIXI.BitmapText if type is BITMAP_TEXT", () => {
+    it("returns PIXI.BitmapText if type is BITMAP_TEXT with style prop", () => {
       const text = "Hello World";
-      const style = { font: "16 Arial" };
+      const style = { font: "16 Arial", align: "left", tint: 0x421337 };
       ReactPixiFiber.createInstance(TYPES.BITMAP_TEXT, { text, style });
+
+      expect(PIXI.extras.BitmapText).toHaveBeenCalledTimes(1);
+      expect(PIXI.extras.BitmapText).toHaveBeenCalledWith(text, style);
+    });
+
+    it("returns PIXI.BitmapText if type is BITMAP_TEXT with font prop", () => {
+      const text = "Hello World";
+      const style = { font: "16 Arial", align: "left", tint: 0x421337 };
+      ReactPixiFiber.createInstance(TYPES.BITMAP_TEXT, {
+        text,
+        font: style.font,
+        align: style.align,
+        tint: style.tint,
+      });
 
       expect(PIXI.extras.BitmapText).toHaveBeenCalledTimes(1);
       expect(PIXI.extras.BitmapText).toHaveBeenCalledWith(text, style);

--- a/test/typescript/index.tsx
+++ b/test/typescript/index.tsx
@@ -7,9 +7,11 @@ import {
   ParticleContainer,
   Sprite,
   Stage,
+  StageClass,
   Text,
   TilingSprite,
   CustomPIXIComponent,
+  createStageClass,
 } from "react-pixi-fiber";
 
 const anchor = new PIXI.ObservablePoint(() => {}, undefined, 0.5, 0.5);
@@ -22,35 +24,163 @@ const CompositionExample: React.FC = () => (
   </Container>
 );
 
-const AnimatedSprite: React.ReactType = CustomPIXIComponent(
+type AnimatedSpriteProps = {
+  textures: PIXI.AnimatedSprite["textures"];
+};
+const AnimatedSprite = CustomPIXIComponent<PIXI.AnimatedSprite, AnimatedSpriteProps>(
   {
-    customDisplayObject: (props: any) => new PIXI.AnimatedSprite(props.textures),
-    customApplyProps: (animatedSprite: PIXI.AnimatedSprite, oldProps: any, newProps: any) => {},
-    customDidAttach: (animatedSprite: PIXI.AnimatedSprite) => {},
-    customWillDetach: (animatedSprite: PIXI.AnimatedSprite) => {},
+    customDisplayObject: props => new PIXI.AnimatedSprite(props.textures),
+    customApplyProps: (instance, oldProps, newProps) => {
+      console.log(instance.animationSpeed);
+      console.log(instance.textures);
+      console.log(oldProps.textures);
+      console.log(newProps.textures);
+    },
+    customDidAttach: instance => {
+      console.log(instance.textures);
+    },
+    customWillDetach: instance => {
+      console.log(instance.textures);
+    },
   },
   "AnimatedSprite"
 );
-const CustomPIXIComponentExample: React.FC = () => <AnimatedSprite />;
 
-const StageExample: React.FC = () => {
-  const stageRef = React.useRef(null);
-  const spriteRef = React.useRef(null);
+interface WickedContainerProps {
+  isJungleMassive?: boolean;
+  isWicked: boolean;
+}
+
+class WickedContainerClass extends PIXI.Container implements WickedContainerProps {
+  isJungleMassive: boolean | undefined;
+  isWicked: boolean;
+
+  constructor(isWicked: boolean) {
+    super();
+
+    this.isWicked = isWicked;
+  }
+}
+
+const WickedContainer = CustomPIXIComponent<WickedContainerClass, WickedContainerProps>(
+  {
+    customDisplayObject: props => {
+      const instance = new WickedContainerClass(props.isWicked);
+
+      if (props.isJungleMassive) {
+        instance.isJungleMassive = props.isJungleMassive;
+      }
+
+      return instance;
+    },
+    customApplyProps: (instance, oldProps, newProps) => {
+      console.log(instance.children);
+      console.log(instance.isWicked);
+      console.log(oldProps.isJungleMassive);
+    },
+    customDidAttach: instance => {
+      console.log(instance.isWicked);
+    },
+    customWillDetach: instance => {
+      console.log(instance.isJungleMassive);
+    },
+  },
+  "WickedContainer"
+);
+
+const CustomPIXIComponentExample: React.FC = () => <AnimatedSprite textures={[]} />;
+
+const StageClassExample: React.FC = () => {
+  const Stage = createStageClass();
+
+  const stageRef = React.useRef<StageClass>(null);
+  const spriteRef = React.useRef<PIXI.Sprite>(null);
+  const wickedContainerRef = React.useRef<WickedContainerClass>(null);
+
+  React.useEffect(() => {
+    if (stageRef.current) {
+      console.log("stageRef", stageRef.current._app);
+      console.log("stageRef", stageRef.current.props);
+    }
+
+    if (spriteRef.current) {
+      console.log("spriteRef", spriteRef.current.position);
+      console.log("spriteRef", spriteRef.current.children);
+    }
+
+    if (wickedContainerRef.current) {
+      console.log("wickedContainerRef", wickedContainerRef.current.children);
+      console.log("wickedContainerRef", wickedContainerRef.current.isWicked);
+      console.log("wickedContainerRef", wickedContainerRef.current.isJungleMassive);
+    }
+  }, []);
 
   return (
-    <Stage options={{ backgroundColor: 0xffffff }} ref={stageRef}>
-      <BitmapText text="" />
-      <Container>
+    <Stage key="stage" options={{ backgroundColor: 0xffffff }} ref={stageRef}>
+      <BitmapText
+        key="bitmapText1"
+        text="Bitmap text 1"
+        style={{ font: { name: "Font", size: 42 }, align: "left", tint: 0xffffff }}
+      />
+      <BitmapText key="bitmapText2" text="Bitmap text 2" font={{ name: "Font", size: 42 }} align="left" tint={0xffffff} />
+      <Container position="10,10">
         <BitmapText text="" />
       </Container>
       <Graphics />
       <ParticleContainer autoResize={false}>
         <Sprite texture={PIXI.Texture.WHITE} />
       </ParticleContainer>
-      <Sprite anchor={anchor} texture={texture} ref={spriteRef} />
+      <Sprite anchor={anchor} texture={texture} ref={spriteRef} interactive pointerup={(): void => {}} />
+      <Text text="Regular text" />
+      <TilingSprite texture={texture} />
+      <CompositionExample />
+      <AnimatedSprite animationSpeed={2} textures={[]} position="0,10" />
+      <WickedContainer isWicked={false} />
+      <WickedContainer isWicked={true} isJungleMassive={true} ref={wickedContainerRef} />
+    </Stage>
+  );
+};
+
+const StageFunctionExample: React.FC = () => {
+  const stageRef = React.useRef<PIXI.Container>(null);
+  const spriteRef = React.useRef<PIXI.Sprite>(null);
+  const wickedContainerRef = React.useRef<WickedContainerClass>(null);
+
+  React.useEffect(() => {
+    if (stageRef.current) {
+      console.log("stageRef", stageRef.current.children);
+      console.log("stageRef", stageRef.current.position);
+    }
+
+    if (spriteRef.current) {
+      console.log("spriteRef", spriteRef.current.position);
+      console.log("spriteRef", spriteRef.current.children);
+    }
+
+    if (wickedContainerRef.current) {
+      console.log("wickedContainerRef", wickedContainerRef.current.children);
+      console.log("wickedContainerRef", wickedContainerRef.current.isWicked);
+      console.log("wickedContainerRef", wickedContainerRef.current.isJungleMassive);
+    }
+  }, []);
+
+  return (
+    <Stage key="stage" options={{ backgroundColor: 0xffffff }}>
+      <BitmapText key="bitmapText" text="" />
+      <Container position="10,10">
+        <BitmapText text="" />
+      </Container>
+      <Graphics />
+      <ParticleContainer autoResize={false}>
+        <Sprite texture={PIXI.Texture.WHITE} />
+      </ParticleContainer>
+      <Sprite anchor={anchor} texture={texture} ref={spriteRef} interactive pointerup={(): void => {}} />
       <Text />
       <TilingSprite texture={texture} />
       <CompositionExample />
+      <AnimatedSprite animationSpeed={2} textures={[]} position="0,10" />
+      <WickedContainer isWicked={false} />
+      <WickedContainer isWicked={true} isJungleMassive={true} ref={wickedContainerRef} />
     </Stage>
   );
 };


### PR DESCRIPTION
- Added `style` prop to `BitmapText` type (`style` is used in constructor).
- Fixed type definitions to work with both PixiJS v4 and v5 (fixes #150).
- Fixed type definitions for properties of type `any` being incorrectly replaced with `PointLike`, e.g. `font` property of `BitmapText`.
- Fixed type definitions for built-in components to be able to use `ref`s.
- Fixed type definitions for `AppContext` which was exported as type, not as value.

----

Example usage of `BitmapText.style` and `ref`s with TypeScript:
```tsx
import { BitmapText, Container, StageClass, createStageClass } from "react-pixi-fiber";

const Stage = createStageClass();

export default function App() {
  const containerRef = React.useRef<PIXI.Container>(null);
  const stageRef = React.useRef<StageClass>(null);

  React.useEffect(() => {
    if (containerRef.current) {
      console.log("containerRef", containerRef.current.position);
    }

    if (stageRef.current) {
      console.log("stageRef", stageRef.current._app);
    }
  }, []);

  return (
    {/* cannot get `ref` of function component, using class-based `Stage` here */}
    <Stage options={{ height: 600, width: 800 }} ref={stageRef}>
      {/* it is now possible to use `ref` with correct type */}
      <Container ref={containerRef}>
        {/* TypeScript does not complain about `style` prop */}
        <BitmapText
          text="Hello world!"
          style={{ font: { name: "Font", size: 20 }, align: "center" }}
        />
      </Container>
    </Stage>
  );
}


```