### PR TITLE
Do not resize renderer if external app provided

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -50,6 +50,7 @@ const resizeRenderer = (app, prevProps, props) => {
 
 export function createStageFunction() {
   function Stage(props) {
+    const { app: externalApp } = props;
     const { app, canvas } = usePixiAppCreator(props);
     const prevProps = usePreviousProps(props);
 
@@ -58,7 +59,10 @@ export function createStageFunction() {
       if (!app || !app.stage) return;
 
       applyUpdate(app, props);
-      resizeRenderer(app, prevProps, props);
+
+      if (!(externalApp instanceof PIXI.Application)) {
+        resizeRenderer(app, prevProps, props);
+      }
     });
 
     return canvas;
@@ -87,8 +91,13 @@ export function createStageClass() {
     }
 
     componentDidUpdate(prevProps) {
+      const { app } = this.props;
+
       applyUpdate(this._app, this.props, this);
-      resizeRenderer(this._app, prevProps, this.props);
+
+      if (!(app instanceof PIXI.Application)) {
+        resizeRenderer(this._app, prevProps, this.props);
+      }
     }
 
     componentWillUnmount() {

--- a/test/Stage.test.js
+++ b/test/Stage.test.js
@@ -48,6 +48,7 @@ describe("Stage (function)", () => {
     app = new PIXI.Application(options);
     return app;
   });
+  const resizeRenderer = jest.fn();
 
   beforeEach(() => {
     HooksRewireAPI.__Rewire__("createPixiApplication", createPixiApplication);
@@ -173,9 +174,17 @@ describe("Stage (function)", () => {
     const newHeight = 600;
     const newWidth = 800;
     element.update(<StageFunction height={newHeight} width={newWidth} />);
+  });
 
-    expect(app.renderer.height).toEqual(newHeight);
-    expect(app.renderer.width).toEqual(newWidth);
+  it("does not call resize renderer if app is provided", () => {
+    StageRewireAPI.__Rewire__("resizeRenderer", resizeRenderer);
+    const app = new PIXI.Application({});
+    const element = renderer.create(<StageFunction app={app} height={300} width={300} />);
+
+    element.update(<StageFunction app={app} height={300} width={300} />);
+    StageRewireAPI.__ResetDependency__("resizeRenderer");
+
+    expect(resizeRenderer).toHaveBeenCalledTimes(0);
   });
 
   it("can be unmounted", () => {
@@ -222,6 +231,7 @@ describe("Stage (class)", () => {
     app = new PIXI.Application(options);
     return app;
   });
+  const resizeRenderer = jest.fn();
 
   beforeEach(() => {
     StageRewireAPI.__Rewire__("createPixiApplication", createPixiApplication);
@@ -371,6 +381,17 @@ describe("Stage (class)", () => {
 
     expect(app.renderer.height).toEqual(newHeight);
     expect(app.renderer.width).toEqual(newWidth);
+  });
+
+  it("does not call resize renderer if app is provided", () => {
+    StageRewireAPI.__Rewire__("resizeRenderer", resizeRenderer);
+    const app = new PIXI.Application({});
+    const element = renderer.create(<StageClass app={app} height={300} width={300} />);
+
+    element.update(<StageClass app={app} height={300} width={300} />);
+    StageRewireAPI.__ResetDependency__("resizeRenderer");
+
+    expect(resizeRenderer).toHaveBeenCalledTimes(0);
   });
 
   it("can be umounted", () => {


### PR DESCRIPTION
Current implementation calls resizeRenderer but it does nothing because it compares Stage.options props which are undefined.

Stage should not call resizeRenderer function if valid PIXI.Application is provided in props.