### PR TITLE
fix: add React 18 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "peerDependencies": {
     "pixi.js": "^4.4.0 || ^5.0.0 || ^6.0.0",
     "prop-types": "^15.7.2",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
`npm install` fails when using React 18 because it is missing from peer dependencies.