### PR TITLE
remove inline require for esm compatibility

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -1,7 +1,8 @@
 import invariant from "fbjs/lib/invariant";
+import { version } from "react";
 
 export function getDevToolsVersion() {
-  return require("react").version;
+  return version;
 }
 
 export const roots = new Map();


### PR DESCRIPTION
There's an inline `require` statement in the current esmodules build and this isn't a recognised expression in esmodules, so it breaks with tools like [Vite](https://vitejs.dev/) which have no commonjs support.

This PR moves the inline require to a regular import

https://unpkg.com/react-pixi-fiber@1.0.1/es/react-pixi-fiber.production.min.js
<img width="621" alt="Screenshot 2022-08-29 at 12 10 35" src="https://user-images.githubusercontent.com/101902546/187246145-d776aa47-03e3-462c-9eca-6c46fc6182de.png">
