### PR TITLE
Check that container exists before calling `removeChildren`

### DIFF
--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -119,7 +119,9 @@ export function cancelTimeout(id) {
 }
 
 export function clearContainer(container) {
-  container && container.removeChildren();
+  if (container) {
+    container.removeChildren();
+  }
 }
 
 export function commitMount(instance, type, props, internalHandle) {

--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -119,7 +119,7 @@ export function cancelTimeout(id) {
 }
 
 export function clearContainer(container) {
-  container.removeChildren();
+  container && container.removeChildren();
 }
 
 export function commitMount(instance, type, props, internalHandle) {


### PR DESCRIPTION
This addresses an error I've repeatedly encountered in production (may have something to do with `React.Suspense` and/or `React.lazy` imports. Just ensures that the container exists before attempting to remove its contents.

```
TypeError: Cannot read properties of null (reading 'removeChildren')
	at removeChildren (../../src/ReactPixiFiber.js:122:12)
	at xb (../../node_modules/react-reconciler/cjs/react-reconciler.production.min.js:131:296)
	at Jf (../../node_modules/react-reconciler/cjs/react-reconciler.production.min.js:174:304)
	at ih (../../node_modules/react-reconciler/cjs/react-reconciler.production.min.js:171:235)
	at vc (../../node_modules/react-reconciler/cjs/react-reconciler.production.min.js:36:324)
	at Pc (../../node_modules/react-reconciler/cjs/react-reconciler.production.min.js:169:278)
	at Zg (../../node_modules/react-reconciler/cjs/react-reconciler.production.min.js:160:369)
```