### PR TITLE
Ensure DOM node exists before calling `node.removeChild` & `node.addChild`

### DIFF
--- a/src/ReactPixiFiber.js
+++ b/src/ReactPixiFiber.js
@@ -21,6 +21,8 @@ if (__DEV__) {
 const noTimeout = -1;
 
 export function appendChild(parentInstance, child) {
+  if (parentInstance == null) return;
+
   // TODO do we need to remove the child first if it's already added?
   parentInstance.removeChild(child);
 


### PR DESCRIPTION
After patching a very similar issue https://github.com/michalochman/react-pixi-fiber/pull/286 it's gotten a bit further downstream but it's still attempting to manipulate missing DOM nodes. Thus I'm introducing another null check to prevent that. I still think `React.Suspense` being somewhat incompatible with `react-reconciler` is the root cause but I'm hoping this workaround is sufficient for our needs🤞