### PR TITLE
Support Pixi 7 events

### DIFF
--- a/src/PixiPropertyOperations.js
+++ b/src/PixiPropertyOperations.js
@@ -35,7 +35,7 @@ export function setValueForProperty(type, instance, propName, value, prevValue, 
     // Can't apply the same shouldIgnoreValue logic to event listeners,
     // otherwise we might loose the reference to prevValue without unsubscribing
     // it beforehand
-    const eventName = propKey.substring(2);
+    const eventName = propName.substring(2);
     replacePixiCallback(instance, eventName, value, prevValue);
     return;
   }

--- a/src/ReactPixiFiberComponent.js
+++ b/src/ReactPixiFiberComponent.js
@@ -161,7 +161,7 @@ export function diffProperties(type, instance, lastRawProps, nextRawProps) {
 export function applyDisplayObjectProps(type, instance, oldProps, newProps) {
   const updatePayload = diffProperties(type, instance, oldProps, newProps);
   if (updatePayload !== null) {
-    updatePixiProperties(type, instance, updatePayload);
+    updatePixiProperties(type, instance, updatePayload, oldProps);
   }
 }
 
@@ -176,7 +176,7 @@ export function updatePixiProperties(type, instance, updatePayload, prevProps, n
     if (propKey === CHILDREN) {
       // Noop. Text children not supported
     } else {
-      setValueForProperty(type, instance, propKey, propValue, internalHandle);
+      setValueForProperty(type, instance, propKey, propValue, prevProps[propKey], internalHandle);
     }
   }
 }

--- a/src/ReactPixiFiberComponent.js
+++ b/src/ReactPixiFiberComponent.js
@@ -176,7 +176,7 @@ export function updatePixiProperties(type, instance, updatePayload, prevProps, n
     if (propKey === CHILDREN) {
       // Noop. Text children not supported
     } else {
-      setValueForProperty(type, instance, propKey, propValue, prevProps[propKey], internalHandle);
+      setValueForProperty(type, instance, propKey, propValue, prevProps?.[propKey], internalHandle);
     }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,6 +86,15 @@ export function copyPoint(instance, propName, value) {
   }
 }
 
+export function replacePixiCallback(instance, eventName, listener, prevListener) {
+  if (typeof prevListener === "function") {
+    instance.off(eventName, prevListener);
+  }
+  if (typeof listener === "function") {
+    instance.on(eventName, listener);
+  }
+}
+
 // Set props on a DisplayObject by checking the type. If a PIXI.Point or
 // a PIXI.ObservablePoint is having its value set, then either a comma-separated
 // string with in the form of "x,y" or a size 2 array with index 0 being the x


### PR DESCRIPTION
Hey!

Pixi.js 7.0.0 finally got released, so I thought about how we can support it in this project. So far I experimented with the typings and wanted to ask you for some feedback:

The `Interaction` package got replaced by the `events` package in version 7, which has way better typings for the `EventEmitter`s. Therefore it is now possible to derive the event names and callback parameters directly from Pixi instead of hardcoding them.

Notice that I put a `on` prefix on all event listeners (so e.g. `click` becomes `onclick`). The motivation was that this gives us an easy way to distinguish event handlers from ordinary props in the runtime (so we can correctly assign them as event handlers instead of just assigning them like all other properties). Another benefit is that it is closer to what `react-dom` does (`onClick`). (BTW: we can also do camelCase in the typings, it would just be an additional `.toLowerCase` call at runtime). Technically it is a breaking change, but it only applies when you update to Pixi.js 7 and then you have to adapt your handlers anyways.

But I wanted to ask for your opinion. We can also adapt the typings without the `on` prefix and have a hard coded list of event names or use some other technique. Depending on your feedback I would implement the runtime accordingly.

Notes:
* No runtime code change so far, but this will also be part of this PR
* For Pixi.js <= 6 the typings are exactly the same as before
* This requires Typescript 4.1, but we can use [types versions](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions) to make this backwards compatible
* Currently I just use the `PIXI.DisplayObjectEvents` type, but this can probably be improved. Haven't tested yet if this typing correctly takes the events from the component
  ```typescript
  type Test<T> = T extends EventEmitter<infer EventTypes extends PIXI.DisplayObjectEvents>
  ? {
    [P in EventEmitter.EventNames<EventTypes>
      as P extends string ? `on${P}` : never
    ]?: EventEmitter.EventListener<EventTypes, P>
  }
  : never
  ```
* Pixi.js 7 also added support for `*capture` events (e.g. `clickcapture`). They don't show up in their typings and therefore are also not present in our typings. But I think this is a bug in Pixi.js (but will check this and will open a PR if necessary)