### PR TITLE
Support Pixi 7.1 events

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,13 @@ declare module "react-pixi-fiber" {
   // shipped in pixi.js@5.3.0. We want to support earlier versions of PixiJS as well so we need this hack for now.
   // @ts-ignore TS2694
   type InteractionCompatibility = Exclude<keyof typeof PIXI.interaction, number | symbol>;
-  type InteractionEvent = string extends InteractionCompatibility
+  // Returns either real keys of `PIXI.InteractionEvent` (if it exists) or generic `string` (if it doesn't exist).
+  // `PIXI.InteractionEvent` was removed in pixi.js@7.0.0.
+  // @ts-ignore TS2694
+  type InteractionEventCompatibility = Exclude<keyof typeof PIXI.InteractionEvent, number | symbol>;
+  type InteractionEvent = string extends InteractionEventCompatibility
+    ? never
+    : string extends InteractionCompatibility
     // @ts-ignore TS2694
     ? PIXI.InteractionEvent
     // @ts-ignore TS2694
@@ -99,7 +105,12 @@ declare module "react-pixi-fiber" {
    */
 
   // Extra properties to add to allow us to set event handlers using props.
-  export type InteractiveComponent = { [P in InteractionEventTypes]?: (event: InteractionEvent) => void };
+  export type InteractiveComponent =
+    InteractionEvent extends never
+    // pixi.js >= 7
+    ? { }
+    // pixi.js <= 6
+    : { [P in InteractionEventTypes]?: (event: InteractionEvent) => void };
 
   /**
    * Base components

--- a/src/PixiProperty.js
+++ b/src/PixiProperty.js
@@ -167,6 +167,7 @@ export const customProperties = {};
 });
 
 [
+  // pixi.js < 7.0
   "added",
   "click",
   "mousedown",
@@ -194,6 +195,37 @@ export const customProperties = {};
   "touchendoutside",
   "touchmove",
   "touchstart",
+  // pixi.js >= 7.1
+  "onclick",
+  "onmousedown",
+  "onmouseenter",
+  "onmouseleave",
+  "onmousemove",
+  "onmouseout",
+  "onmouseover",
+  "onmouseup",
+  "onmouseupoutside",
+  "onpointercancel",
+  "onpointerdown",
+  "onpointerenter",
+  "onpointerleave",
+  "onpointermove",
+  "onpointerout",
+  "onpointerover",
+  "onpointertap",
+  "onpointerup",
+  "onpointerupoutside",
+  "onrightclick",
+  "onrightdown",
+  "onrightup",
+  "onrightupoutside",
+  "ontap",
+  "ontouchcancel",
+  "ontouchend",
+  "ontouchendoutside",
+  "ontouchmove",
+  "ontouchstart",
+  "onwheel",
 ].forEach(name => {
   properties[name] = new PropertyInfoRecord(name, CALLBACK);
 });

--- a/src/possibleStandardNames.js
+++ b/src/possibleStandardNames.js
@@ -3,6 +3,7 @@ import { TYPES } from "./types";
 
 // http://pixijs.download/release/docs/PIXI.DisplayObject.html
 const eventsStandardNames = {
+  // pixi.js < 7.0
   added: "added",
   click: "click",
   mousedown: "mousedown",
@@ -30,6 +31,37 @@ const eventsStandardNames = {
   touchendoutside: "touchendoutside",
   touchmove: "touchmove",
   touchstart: "touchstart",
+  // pixi.js >= 7.1
+  onclick: "onclick",
+  onmousedown: "onmousedown",
+  onmouseenter: "onmouseenter",
+  onmouseleave: "onmouseleave",
+  onmousemove: "onmousemove",
+  onmouseout: "onmouseout",
+  onmouseover: "onmouseover",
+  onmouseup: "onmouseup",
+  onmouseupoutside: "onmouseupoutside",
+  onpointercancel: "onpointercancel",
+  onpointerdown: "onpointerdown",
+  onpointerenter: "onpointerenter",
+  onpointerleave: "onpointerleave",
+  onpointermove: "onpointermove",
+  onpointerout: "onpointerout",
+  onpointerover: "onpointerover",
+  onpointertap: "onpointertap",
+  onpointerup: "onpointerup",
+  onpointerupoutside: "onpointerupoutside",
+  onrightclick: "onrightclick",
+  onrightdown: "onrightdown",
+  onrightup: "onrightup",
+  onrightupoutside: "onrightupoutside",
+  ontap: "ontap",
+  ontouchcancel: "ontouchcancel",
+  ontouchend: "ontouchend",
+  ontouchendoutside: "ontouchendoutside",
+  ontouchmove: "ontouchmove",
+  ontouchstart: "ontouchstart",
+  onwheel: "onwheel",
 };
 
 // http://pixijs.download/release/docs/PIXI.DisplayObject.html


### PR DESCRIPTION
Utilizes the work in https://github.com/pixijs/pixijs/pull/8876 to support event handler props for Pixi.js >= 7.1

Note: Pixi.js 7.1 isn't released yet and I also have to test the typings for Pixi < 7